### PR TITLE
Allow italics and other markup in SVRL results

### DIFF
--- a/resources/validations/bin/validate_with_schematron.sh
+++ b/resources/validations/bin/validate_with_schematron.sh
@@ -34,15 +34,25 @@ for qualifiedSchematronName in src/*.sch; do
     
     # Use Saxon XSL transform to convert our Schematron to pure XSL 2.0 stylesheet
     saxon_jar=~/.m2/repository/net/sf/saxon/Saxon-HE/"${SAXON_VERSION}"/Saxon-HE-"${SAXON_VERSION}".jar
-    java -cp "${saxon_jar}" net.sf.saxon.Transform -o:target/"${schematronRoot}".xsl -s:"${qualifiedSchematronName}" lib/schematron/trunk/schematron/code/iso_svrl_for_xslt2.xsl
+    java -cp "${saxon_jar}" net.sf.saxon.Transform \
+        -o:target/"${schematronRoot}".xsl \
+        -s:"${qualifiedSchematronName}" \
+        lib/schematron/trunk/schematron/code/iso_svrl_for_xslt2.xsl
     echo "compiling: ${qualifiedSchematronName} to: target/${schematronRoot}.xsl"
    
     # Use Saxon XSL transform to use XSL-ified Schematron rules to analyze full FedRAMP-SSP-OSCAL template
     # and dump the result into reports.
     reportName="report/schematron/${DOC_TO_VALIDATE}__${schematronRoot}.results.xml"
     htmlReportName="report/html/${DOC_TO_VALIDATE}__${schematronRoot}.results.html"
+
     echo "validating doc: ${DOC_TO_VALIDATE} with ${qualifiedSchematronName} output found in ${reportName}"
-    java -cp "${saxon_jar}" net.sf.saxon.Transform -o:"${reportName}" -s:"${DOC_TO_VALIDATE}" target/"${schematronRoot}".xsl
-    java -cp "${saxon_jar}" net.sf.saxon.Transform -o:"${htmlReportName}" -s:"${reportName}"  lib/svrl2html.xsl
+
+    java -cp "${saxon_jar}" net.sf.saxon.Transform \
+        -o:"${reportName}" -s:"${DOC_TO_VALIDATE}" \
+        target/"${schematronRoot}".xsl
+    java -cp "${saxon_jar}" net.sf.saxon.Transform \
+        -o:"${htmlReportName}" \
+        -s:"${reportName}"  \
+        lib/svrl2html.xsl \
 
 done

--- a/resources/validations/bin/validate_with_schematron.sh
+++ b/resources/validations/bin/validate_with_schematron.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o pipefail
+
 if [ ! -e  "$1" ]; then
     echo "no file input for report, exiting"
     exit 1

--- a/resources/validations/bin/validate_with_schematron.sh
+++ b/resources/validations/bin/validate_with_schematron.sh
@@ -9,8 +9,10 @@ echo "doc requested to be validated: ${DOC_TO_VALIDATE}"
 
 # Delete pre-existing XSLT report
 rm -rf target/*.xsl;
+
 SAXON_VERSION=$2
 SAXON_VERSION=${SAXON_VERSION:-10.2}
+SAXON_OPTS="${SAXON_OPTS:-allow-foreign=true}"
 
 echo "using saxon version ${SAXON_VERSION}"
 

--- a/resources/validations/bin/validate_with_schematron.sh
+++ b/resources/validations/bin/validate_with_schematron.sh
@@ -37,7 +37,9 @@ for qualifiedSchematronName in src/*.sch; do
     java -cp "${saxon_jar}" net.sf.saxon.Transform \
         -o:target/"${schematronRoot}".xsl \
         -s:"${qualifiedSchematronName}" \
-        lib/schematron/trunk/schematron/code/iso_svrl_for_xslt2.xsl
+        lib/schematron/trunk/schematron/code/iso_svrl_for_xslt2.xsl \
+        $SAXON_OPTS
+
     echo "compiling: ${qualifiedSchematronName} to: target/${schematronRoot}.xsl"
    
     # Use Saxon XSL transform to use XSL-ified Schematron rules to analyze full FedRAMP-SSP-OSCAL template
@@ -49,10 +51,13 @@ for qualifiedSchematronName in src/*.sch; do
 
     java -cp "${saxon_jar}" net.sf.saxon.Transform \
         -o:"${reportName}" -s:"${DOC_TO_VALIDATE}" \
-        target/"${schematronRoot}".xsl
+        target/"${schematronRoot}".xsl \
+        $SAXON_OPTS
+
     java -cp "${saxon_jar}" net.sf.saxon.Transform \
         -o:"${htmlReportName}" \
         -s:"${reportName}"  \
         lib/svrl2html.xsl \
+        $SAXON_OPTS
 
 done

--- a/resources/validations/bin/validate_with_schematron.sh
+++ b/resources/validations/bin/validate_with_schematron.sh
@@ -34,6 +34,7 @@ for qualifiedSchematronName in src/*.sch; do
     
     # Use Saxon XSL transform to convert our Schematron to pure XSL 2.0 stylesheet
     saxon_jar=~/.m2/repository/net/sf/saxon/Saxon-HE/"${SAXON_VERSION}"/Saxon-HE-"${SAXON_VERSION}".jar
+
     java -cp "${saxon_jar}" net.sf.saxon.Transform \
         -o:target/"${schematronRoot}".xsl \
         -s:"${qualifiedSchematronName}" \


### PR DESCRIPTION
[Per conversation with NIST OSCAL developers](https://gitter.im/usnistgov-OSCAL/FedRAMP-10x-Schematron?at=5f9afbb5f2fd4f60fc3fecfe), if we want to evaluate the potential of markup from other namespaces (things not strictly in the Schematron namespace), as a prerequisite, we need to set the `allow-foreign` attribute.

This is part of exploratory testing for #2.

