### PR TITLE
OSCAL 1.0.0-rc2 annotation changed to prop

### DIFF
--- a/resources/validations/src/ssp.sch
+++ b/resources/validations/src/ssp.sch
@@ -230,7 +230,7 @@
         <sch:assert role="error" organizational-id="section-c.3" id="incomplete-core-implemented-requirements" test="not(exists($core-missing))">[Section C Check 3] This SSP has not implemented the most important <sch:value-of select="count($core-missing)"/> core<sch:value-of select="if (count($core-missing)=1) then ' control' else ' controls'"/>: <sch:value-of select="$core-missing/@id"/></sch:assert>
         <sch:assert role="warn" organizational-id="section-c.2" id="incomplete-all-implemented-requirements" test="not(exists($all-missing))">[Section C Check 2] This SSP has not implemented <sch:value-of select="count($all-missing)"/><sch:value-of select="if (count($all-missing)=1) then ' control' else ' controls'"/> overall: <sch:value-of select="$all-missing/@id"/></sch:assert>
         <sch:assert role="warn" organizational-id="section-c.2" id="extraneous-implemented-requirements" test="not(exists($extraneous))">[Section C Check 2] This SSP has implemented <sch:value-of select="count($extraneous)"/> extraneous<sch:value-of select="if (count($extraneous)=1) then ' control' else ' controls'"/> not needed given the selected profile: <sch:value-of select="$extraneous/@control-id"/></sch:assert>
-        <sch:let name="results" value="$ok-values => lv:analyze(//o:implemented-requirement/o:annotation[@name='implementation-status'])"/>
+        <sch:let name="results" value="$ok-values => lv:analyze(//o:implemented-requirement/o:prop[@name='implementation-status'])"/>
         <sch:let name="total" value="$results/reports/@count"/>
         <sch:report role="positive" id="control-implemented-requirements-stats" test="count($results/errors/error) = 0"><sch:value-of select="$results => lv:report() => normalize-space()"/></sch:report>
     </sch:rule>
@@ -240,7 +240,7 @@
         <sch:let name="selected-profile" value="$sensitivity-level => lv:profile()"/>
         <sch:let name="registry" value="$registry-href => lv:registry()"/>
         <sch:let name="registry-ns" value="$registry/f:fedramp-values/f:namespace/f:ns/@ns"/>
-        <sch:let name="status" value="./o:annotation[@name='implementation-status']/@value"/>
+        <sch:let name="status" value="./o:prop[@name='implementation-status']/@value"/>
         <sch:let name="corrections" value="lv:correct($registry/f:fedramp-values/f:value-set[@name='control-implementation-status'], $status)"/>
         <sch:let name="required-response-points" value="$selected-profile/o:catalog//o:part[@name='item']"/>
         <sch:let name="implemented" value="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:statement"/>

--- a/resources/validations/test/ssp.xspec
+++ b/resources/validations/test/ssp.xspec
@@ -65,9 +65,9 @@
                             </system-characteristics>
                             <control-implementation>
                                 <implemented-requirement control-id="at-1" uuid="eee8697a-bc39-45aa-accc-d3e534932efb">
-                                    <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="inconceivable">
+                                    <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="inconceivable">
                                     <remarks></remarks>
-                                    </annotation>
+                                    </prop>
                                 </implemented-requirement>
                             </control-implementation>
                         </system-security-plan>
@@ -82,9 +82,9 @@
                             </system-characteristics>
                             <control-implementation>
                                 <implemented-requirement control-id="cm-1" uuid="eee8697a-bc39-45aa-accc-d3e534932efb">
-                                    <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented">
+                                    <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented">
                                     <remarks></remarks>
-                                    </annotation>
+                                    </prop>
                                 </implemented-requirement>
                             </control-implementation>
                         </system-security-plan>
@@ -101,9 +101,9 @@
                         <control-implementation>
                             <implemented-requirement control-id="ac-1" uuid="eee8697a-bc39-45aa-accc-d3e534932efb">
                                 <prop name="planned-completion-date" ns="https://fedramp.gov/ns/oscal">2020-11-27Z</prop>
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned">
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="planned">
                                 <remarks></remarks>
-                                </annotation>
+                                </prop>
                             </implemented-requirement>
                         </control-implementation>
                     </system-security-plan>
@@ -210,7 +210,7 @@
                             <control-implementation>
                                 <!-- Requirements and lettered responses for AC-7 are complete, so these will be absent from the report. -->
                                 <implemented-requirement control-id="ac-7" uuid="c1a9916f-cba6-4910-b2ea-b4ba17b03480">
-                                    <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                    <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                                     <statement statement-id="ac-7_smt.a" uuid="8d8e73f3-b966-4b3e-a545-93923885ba2a">
                                         <by-component component-uuid="5129f6ad-53f7-47be-9e5c-22728012264a" uuid="fa680b3c-9da9-443f-9a4c-db731a5218f7">
                                             <description>
@@ -249,7 +249,7 @@
                             </system-implementation>
                             <control-implementation>
                                 <implemented-requirement control-id="ac-1" uuid="c1a9916f-cba6-4910-b2ea-b4ba17b03480">
-                                    <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                    <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                                 </implemented-requirement>
                             </control-implementation>
                         </system-security-plan>
@@ -442,190 +442,190 @@
                         <!-- For thee FedRAMP Low Baseline, there are 62 CORE controls. -->
                         <control-implementation>
                             <implemented-requirement control-id="ac-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ac-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ac-7">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ac-17">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ac-18">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ac-19">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ac-22">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="at-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="at-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="at-3">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="at-4">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="au-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="au-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="au-6">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="au-11">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ca-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ca-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ca-3">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ca-5">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ca-7">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ca-9">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cm-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cm-6">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cm-8">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cp-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cp-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cp-3">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cp-4">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="cp-9">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ia-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ia-4">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ia-5">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ia-5.1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ir-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ir-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ir-6">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ir-8">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ma-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ma-4">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="mp-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pe-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pe-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pe-3">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pe-6">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pe-8">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pl-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="pl-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ps-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ps-3">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ps-4">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ps-5">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ps-6">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ps-7">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ra-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="ra-5">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="sa-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="sc-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="sc-13">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="si-1">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="si-2">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="si-3">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                             <implemented-requirement control-id="si-4">
-                                <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
+                                <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented"/>
                             </implemented-requirement>
                         </control-implementation>
                     </system-security-plan>
@@ -646,9 +646,9 @@
                     </system-characteristics>
                     <control-implementation>
                         <implemented-requirement control-id="ac-5" uuid="373c8a10-7885-4209-9e55-0b69747cb6b9">
-                            <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented">
+                            <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="implemented">
                             <remarks></remarks>
-                            </annotation>
+                            </prop>
                         </implemented-requirement>
                     </control-implementation>
                 </system-security-plan>
@@ -668,9 +668,9 @@
                     </system-characteristics>
                     <control-implementation>
                         <implemented-requirement control-id="ac-1" uuid="4b81d5aa-2149-4b7b-ab28-69e390226784">
-                            <annotation name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial">
+                            <prop name="implementation-status" ns="https://fedramp.gov/ns/oscal" value="partial">
                             <remarks></remarks>
-                            </annotation>
+                            </prop>
                         </implemented-requirement>
                     </control-implementation>
                 </system-security-plan>

--- a/resources/xml/FedRAMP_extensions.xml
+++ b/resources/xml/FedRAMP_extensions.xml
@@ -958,7 +958,7 @@
          <enum value="not-applicable" label="Not Applicable (N/A)">The assessor finds this control objective does not apply to this system.</enum>
       </allowed-values>
       <remarks>
-         <p>When an extension is an prop, the data type and allowed values must be defined in a separate constraint.</p>
+         <p>When an extension is a prop, the data type and allowed values must be defined in a separate constraint.</p>
       </remarks>
    </constraint>
 

--- a/resources/xml/FedRAMP_extensions.xml
+++ b/resources/xml/FedRAMP_extensions.xml
@@ -634,7 +634,7 @@
       <constraint>
          <has-cardinality min-occurs="0" max-occurs="1" />
          <remarks>
-            <p>When an prop is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
+            <p>When a prop is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
          </remarks>
       </constraint>
    </extension>

--- a/resources/xml/FedRAMP_extensions.xml
+++ b/resources/xml/FedRAMP_extensions.xml
@@ -384,7 +384,7 @@
       <extension-name>connection-security</extension-name>
       <formal-name>Connection Security</formal-name>
       <description>Identifies the mechanisms/protocol(s) used to secure the communication.</description>
-      <binding pattern="/o:system-security-plan/o:system-implementation/o:component[@type='interconnection']/o:annotation" />
+      <binding pattern="/o:system-security-plan/o:system-implementation/o:component[@type='interconnection']/o:prop" />
       <constraint>
          <matches data-type="NCName" />
          <has-cardinality min-occurs="1" max-occurs="unbounded" />
@@ -603,11 +603,11 @@
       <extension-name>implementation-status</extension-name>
       <formal-name>Control Implementation Status</formal-name>
       <description>Indicates the implementation status of the control.</description>
-      <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement/o:annotation"/>
+      <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement/o:prop"/>
       <constraint>
          <has-cardinality min-occurs="1" max-occurs="unbounded" />
          <remarks>
-            <p>When an annotation is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
+            <p>When an prop is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
          </remarks>
       </constraint>
    </extension>
@@ -630,11 +630,11 @@
       <extension-name>control-origination</extension-name>
       <formal-name>Control Origination</formal-name>
       <description>The point(s) from which the control satisfaction originates.</description>
-      <binding pattern="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:annotation"/>
+      <binding pattern="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:prop"/>
       <constraint>
          <has-cardinality min-occurs="0" max-occurs="1" />
          <remarks>
-            <p>When an annotation is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
+            <p>When an prop is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
          </remarks>
       </constraint>
    </extension>
@@ -934,7 +934,7 @@
    <constraint name="control-origination-constraints">
       <formal-name>Control Origination</formal-name>
       <description>The point(s) from which the control satisfaction originates.</description>
-      <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement/o:annotation[@name='control-origination'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
+      <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement/o:prop[@name='control-origination'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
       <matches data-type="NCName" />
       <allowed-values allow-other="no">
          <enum value="sp-corporate" label="SP Corporate">Service Provider (Corporate)</enum>
@@ -948,7 +948,7 @@
    <constraint name="control-implementation-status-constraints">
       <formal-name>Control Implementation Status Constraints</formal-name>
       <description>Defines the data type and allowed values for the Control Implementation Status</description>
-      <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement/o:annotation[@name='implementation-status'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
+      <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement/o:prop[@name='implementation-status'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
       <matches data-type="NCName" />
       <allowed-values allow-other="no">
          <enum value="implemented" label="Implemented">The assessor finds sufficient evidence to agree the control objective is fully implemented.</enum>
@@ -958,7 +958,7 @@
          <enum value="not-applicable" label="Not Applicable (N/A)">The assessor finds this control objective does not apply to this system.</enum>
       </allowed-values>
       <remarks>
-         <p>When an extension is an annotation, the data type and allowed values must be defined in a separate constraint.</p>
+         <p>When an extension is an prop, the data type and allowed values must be defined in a separate constraint.</p>
       </remarks>
    </constraint>
 
@@ -967,7 +967,7 @@
       <description>Remarks are required for certain Control Implementation Status values.</description>
       <binding pattern="/o:system-security-plan/o:control-implmentation/o:implemented-requirement"/>
       <matches data-type="NCName" />
-      <expect test="(o:annotation[@name='planned-completion'][@ns='https://fedramp.gov/ns/oscal'])" />
+      <expect test="(o:prop[@name='planned-completion'][@ns='https://fedramp.gov/ns/oscal'])" />
    </constraint>
  
    <constraint>
@@ -984,13 +984,13 @@
       <formal-name>Planned Implementation Date Exists</formal-name>
       <description>If the control implementation status is "Planned" a "Planned Implementation Date" must be provided.</description>
       <prop name="reference">3.1</prop>
-      <binding pattern="/o:system-security-plan/o:control-implementation/o:implemented-requirement[o:annotation[@name='implementation-status'][@value='planned']]" />
+      <binding pattern="/o:system-security-plan/o:control-implementation/o:implemented-requirement[o:prop[@name='implementation-status'][@value='planned']]" />
       <expect test="(o:prop[@name='implementation-status'][@ns='https://fedramp.gov/ns/oscal'][@value='partial']/remarks)" />
       <expect test="(o:prop[@name='implementation-status'][@ns='https://fedramp.gov/ns/oscal'][@value='planned']/remarks)" />
       <expect test="(o:prop[@name='implementation-status'][@ns='https://fedramp.gov/ns/oscal'][@value='alternative']/remarks)" />
       <expect test="(o:prop[@name='implementation-status'][@ns='https://fedramp.gov/ns/oscal'][@value='not-applicable']/remarks)" />
       <remarks>
-         <p>In the SSP, if <code>implemented-requirement</code> includes <code>annotation[@name='implementation-status']</code> with <code>value='planned'</code>, a <code>planned-completion-date</code> extension must be provided.</p>
+         <p>In the SSP, if <code>implemented-requirement</code> includes <code>prop[@name='implementation-status']</code> with <code>value='planned'</code>, a <code>planned-completion-date</code> extension must be provided.</p>
       </remarks>
    </constraint>
 
@@ -1133,7 +1133,7 @@
    <constraint name="service-model">
       <formal-name>Service Model</formal-name>
       <description>The cloud service model.</description>
-      <binding pattern="/o:system-security-plan/o:system-characteristics/o:annotation[@name='service-model']/@value"/>
+      <binding pattern="/o:system-security-plan/o:system-characteristics/o:prop[@name='service-model']/@value"/>
       <allowed-values allow-other="no">
          <enum value="saas" label="SaaS">Software as a Service</enum>
          <enum value="paas" label="PaaS">Platform as a Service</enum>
@@ -1145,7 +1145,7 @@
    <constraint name="deployment-model">
       <formal-name>Deployment Model</formal-name>
       <description>The cloud deployment model.</description>
-      <binding pattern="/o:system-security-plan/o:system-characteristics/o:annotation[@name='deployment-model']/@value"/>
+      <binding pattern="/o:system-security-plan/o:system-characteristics/o:prop[@name='deployment-model']/@value"/>
       <allowed-values allow-other="no">
          <enum value="public-cloud" label="Public">Public Cloud</enum>
          <enum value="private-cloud" label="Private">Private Cloud</enum>

--- a/resources/xml/FedRAMP_extensions.xml
+++ b/resources/xml/FedRAMP_extensions.xml
@@ -607,7 +607,7 @@
       <constraint>
          <has-cardinality min-occurs="1" max-occurs="unbounded" />
          <remarks>
-            <p>When an prop is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
+            <p>When a prop is defined as an extension, a separate constraint assembly is needed to specify datatype and allowed values on the <code>@value</code> flag.</p>
          </remarks>
       </constraint>
    </extension>

--- a/resources/xml/fedramp_values.xml
+++ b/resources/xml/fedramp_values.xml
@@ -113,7 +113,7 @@
    <value-set name="service-model">
       <formal-name>Service Model</formal-name>
       <description>The cloud service model.</description>
-      <binding pattern="system-characteristics/annotation[@name='service-model']/@value"/>
+      <binding pattern="system-characteristics/prop[@name='service-model']/@value"/>
       <allowed-values allow-other="no">
          <enum value="saas" short-label="SaaS">Software as a Service</enum>
          <enum value="paas" short-label="PaaS">Platform as a Service</enum>
@@ -125,7 +125,7 @@
    <value-set name="deployment-model">
       <formal-name>Deployment Model</formal-name>
       <description>The cloud deployment model.</description>
-      <binding pattern="system-characteristics/annotation[@name='deployment-model']/@value"/>
+      <binding pattern="system-characteristics/prop[@name='deployment-model']/@value"/>
       <allowed-values allow-other="no">
          <enum value="public-cloud" short-label="Public">Public Cloud</enum>
          <enum value="private-cloud" short-label="Private">Private Cloud</enum>
@@ -289,7 +289,7 @@
    <value-set name="user-type">
       <formal-name>User Type</formal-name>
       <description>Identifies the user type.</description>
-      <binding pattern="user/annotation[@name='type']/@value"/>
+      <binding pattern="user/prop[@name='type']/@value"/>
       <allowed-values allow-other="no">
          <enum value="internal" short-label="I">Internal</enum>
          <enum value="external" short-label="E">External</enum>
@@ -300,7 +300,7 @@
    <value-set name="user-privilege">
       <formal-name>User Privilege</formal-name>
       <description>Identifies the privilege level of the user.</description>
-      <binding pattern="user/annotation[@name='privilege-level']/@value"/>
+      <binding pattern="user/prop[@name='privilege-level']/@value"/>
       <allowed-values allow-other="no">
          <enum value="privileged" short-label="P">Privileged</enum>
          <enum value="non-privileged" short-label="NP">Non-Privileged</enum>
@@ -335,7 +335,7 @@
    <value-set name="interconnection-security">
       <formal-name>Interconnection Security</formal-name>
       <description>Identifies the type of security applied to the interconnection.</description>
-      <binding pattern="component[@component-type='interconnection']/annotation[@name='connection-security'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
+      <binding pattern="component[@component-type='interconnection']/prop[@name='connection-security'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
       <allowed-values allow-other="no">
          <enum value="ipsec" short-label="IPsec">IPsec</enum>
          <enum value="vpn" short-label="VPN">Virtual Private Network</enum>
@@ -434,31 +434,31 @@
    <value-set name="allows-authenticated-scan">
       <formal-name>Allows Authenticated Scan</formal-name>
       <description>Indicates if the asset is capable of having an authenticated scan.</description>
-      <binding pattern="inventory-item/annotation[@name='allows-authenticated-scan']/@value"/>
-      <binding pattern="component/annotation[@name='allows-authenticated-scan']/@value"/>
+      <binding pattern="inventory-item/prop[@name='allows-authenticated-scan']/@value"/>
+      <binding pattern="component/prop[@name='allows-authenticated-scan']/@value"/>
       <allowed-values allow-other="no">
          <enum value="yes" short-label="Y">Yes</enum>
          <enum value="no" short-label="N">No</enum>
       </allowed-values>
-      <remarks>if the value is "no", the annotation remarks must contain the reason why.</remarks>
+      <remarks>if the value is "no", the prop remarks must contain the reason why.</remarks>
    </value-set>
    
    <value-set name="is-scanned">
       <formal-name>Is Scanned</formal-name>
       <description>Indicates if the asset is scan.</description>
-      <binding pattern="inventory-item/annotation[@name='is-scanned']/@value"/>
-      <binding pattern="component/annotation[@name='is-scannan']/@value"/>
+      <binding pattern="inventory-item/prop[@name='is-scanned']/@value"/>
+      <binding pattern="component/prop[@name='is-scannan']/@value"/>
       <allowed-values allow-other="no">
          <enum value="yes" short-label="Y">Yes</enum>
          <enum value="no" short-label="N">No</enum>
       </allowed-values>
-      <remarks>if the value is "no", the annotation remarks must contain the reason why.</remarks>
+      <remarks>if the value is "no", the prop remarks must contain the reason why.</remarks>
    </value-set>
    
    <value-set name="control-implementation-status">
       <formal-name>Control Implementation Status</formal-name>
       <description>The implementation status of the control.</description>
-      <binding pattern="implemented-requirement/annotation[@name='implementation-status']/@value"/>
+      <binding pattern="implemented-requirement/prop[@name='implementation-status']/@value"/>
       <allowed-values allow-other="no">
          <enum value="implemented" short-label="Implemented">Implemented</enum>
          <enum value="partial" short-label="Partial">Partially Implemented</enum>
@@ -471,7 +471,7 @@
    <value-set name="control-origination">
       <formal-name>Control Origination</formal-name>
       <description>The point(s) from which the control satisfaction originates.</description>
-      <binding pattern="implemented-requirement/annotation[@name='control-origination'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
+      <binding pattern="implemented-requirement/prop[@name='control-origination'][@ns='https://fedramp.gov/ns/oscal']/@value"/>
       <allowed-values allow-other="no">
          <enum value="sp-corporate" short-label="SP Corporate">Service Provider (Corporate)</enum>
          <enum value="sp-system" short-label="SP System">Service Provider (System Specific)</enum>


### PR DESCRIPTION
This PR changes all occurrences of `<annotation>` to `<prop>` in the Schematron, XSpec, FedRAMP extensions, and FedRAMP value constraints.

The XSpec unit tests had no failures.

Applying `validate_with_schematron.sh` to `src/templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml` shows 22 differences. Results (master branch vs 1.0.0-rc2) in 
[svrl.zip](https://github.com/18F/fedramp-automation/files/6453326/svrl.zip).

By the way, the several `FedRAMP-SSP-OSCAL-Template.xml` differ in version:
```gapinski@nuc7i7bnh:~/Projects/github/18F/fedramp-automation$ find -name FedRAMP-SSP-OSCAL-Template.xml|while read -r ssp; do echo $ssp; grep oscal-version $ssp; done
./oscal/src/release/content-upgrade/FedRAMP-SSP-OSCAL-Template.xml
      <oscal-version>1.0-Milestone3</oscal-version>
            <oscal-version>1.0-Milestone3</oscal-version>
            <oscal-version>1.0-Milestone3</oscal-version>
./src/templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml
      <oscal-version>1.0.0-rc2</oscal-version>
            <oscal-version>1.0.0-rc2</oscal-version>
./resources/validations/test/demo/FedRAMP-SSP-OSCAL-Template.xml
      <oscal-version>1.0-Milestone3</oscal-version>
            <oscal-version>1.0-Milestone3</oscal-version>
            <oscal-version>1.0-Milestone3</oscal-version>
./templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml
      <oscal-version>1.0.0-rc2</oscal-version>
            <oscal-version>1.0.0-rc2</oscal-version>
```