### PR TITLE
Schematron phases

### DIFF
--- a/resources/validations/src/ssp.sch
+++ b/resources/validations/src/ssp.sch
@@ -14,6 +14,52 @@
             uri="https://fedramp.gov/ns/oscal" />
     <sch:ns prefix="lv"
             uri="local-validations" />
+    <sch:phase id="Phase2">
+        <sch:active pattern="phase2" />
+    </sch:phase>
+    <sch:phase id="Phase3">
+        <sch:active pattern="resources" />
+        <sch:active pattern="base64" />
+        <sch:active pattern="specific-attachments" />
+        <sch:active pattern="policy-and-procedure" />
+        <sch:active pattern="privacy1" />
+        <sch:active pattern="privacy2" />
+        <sch:active pattern="fips-140" />
+        <sch:active pattern="fips-199" />
+        <sch:active pattern="sp800-60" />
+        <sch:active pattern="sp800-63" />
+        <sch:active pattern="system-inventory" />
+        <sch:active pattern="basic-system-characteristics" />
+        <sch:active pattern="general-roles" />
+        <sch:active pattern="implementation-roles" />
+        <sch:active pattern="user-properties" />
+        <sch:active pattern="authorization-boundary" />
+        <sch:active pattern="network-architecture" />
+        <sch:active pattern="data-flow" />
+    </sch:phase>
+    <sch:phase id="attachments">
+        <sch:active pattern="resources" />
+        <sch:active pattern="base64" />
+        <sch:active pattern="specific-attachments" />
+        <sch:active pattern="policy-and-procedure" />
+    </sch:phase>
+    <sch:phase id="privacy">
+        <sch:active pattern="privacy1" />
+        <sch:active pattern="privacy2" />
+    </sch:phase>
+    <sch:phase id="inventory">
+        <sch:active pattern="system-inventory" />
+    </sch:phase>
+    <sch:phase id="diagrams">
+        <sch:active pattern="authorization-boundary" />
+        <sch:active pattern="network-architecture" />
+        <sch:active pattern="data-flow" />
+    </sch:phase>
+    <sch:phase id="roles">
+        <sch:active pattern="general-roles" />
+        <sch:active pattern="implementation-roles" />
+        <sch:active pattern="user-properties" />
+    </sch:phase>
     <doc:xspec href="../test/ssp.xspec" />
     <sch:title>FedRAMP System Security Plan Validations</sch:title>
     <xsl:output encoding="UTF-8"
@@ -206,7 +252,7 @@
             <xsl:value-of select="current()/text()" />, so analysis could be inaccurate or it completely failed.</xsl:for-each>
         </xsl:if></xsl:value-of>
     </xsl:template>
-    <sch:pattern>
+    <sch:pattern id="phase2">
         <sch:rule context="/o:system-security-plan">
             <sch:let name="ok-values"
                      value="$registry/f:fedramp-values/f:value-set[@name = 'security-level']" />
@@ -456,7 +502,7 @@
              value="doc(concat($registry-base-path, '/fedramp_values.xml'))" />
     <!-- ↑ stage 2 content ↑ -->
     <!-- ↓ stage 3 content ↓ -->
-    <sch:pattern>
+    <sch:pattern id="resources">
         <sch:title>Basic resource constraints</sch:title>
         <sch:let name="attachment-types"
                  value="$fedramp-values//fedramp:value-set[@name = 'attachment-type']//fedramp:enum/@value" />
@@ -511,7 +557,7 @@
                         test="@media-type = $media-types">A media-type attribute must have an allowed value.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern>
+    <sch:pattern id="base64">
         <sch:title>base64 attachments</sch:title>
         <sch:rule context="oscal:back-matter/oscal:resource">
             <sch:assert diagnostics="resource-has-base64-diagnostic"
@@ -540,7 +586,7 @@
             <!-- FYI: http://expath.org/spec/binary#decode-string handles base64 but Saxon-PE or higher is necessary -->
         </sch:rule>
     </sch:pattern>
-    <sch:pattern>
+    <sch:pattern id="specific-attachments">
         <sch:title>Constraints for specific attachments</sch:title>
         <sch:rule context="oscal:back-matter"
                   see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf">
@@ -598,7 +644,7 @@
                         [Section B Check 3.11] A FedRAMP OSCAL SSP must have a Separation of Duties Matrix attached.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern>
+    <sch:pattern id="policy-and-procedure">
         <sch:title>Policy and Procedure attachments</sch:title>
         <sch:title>A FedRAMP SSP must incorporate one policy document and one procedure document for each of the 17 NIST SP 800-54 Revision 4 control
         families</sch:title>
@@ -651,7 +697,7 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             [Section B Check 3.1] Policy and procedure documents must have unique per-control-family associations.</sch:report>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern>
+    <sch:pattern id="privacy1">
         <sch:title>A FedRAMP OSCAL SSP must specify a Privacy Point of Contact</sch:title>
         <sch:rule context="oscal:metadata"
                   see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 49">
@@ -680,7 +726,7 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         must define a Privacy Point of Contact.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern>
+    <sch:pattern id="privacy2">
         <sch:title>A FedRAMP OSCAL SSP may need to incorporate a PIA and possibly a SORN</sch:title>
         <!-- The "PTA" appears to be just a few questions, not an attachment -->
         <sch:rule context="oscal:prop[@name = 'privacy-sensitive'] | oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and matches(@name, '^pta-\d$')]"
@@ -756,7 +802,8 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             [Section B Check 3.4] This FedRAMP OSCAL SSP must incorporate a Privacy Impact Analysis.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 58">
+    <sch:pattern id="fips-140"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 58">
         <!-- FIXME: Draft guide is wildly different than template -->
         <sch:title>FIPS 140 Validation</sch:title>
         <sch:rule context="oscal:system-implementation">
@@ -802,8 +849,9 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         validation-details link must be in accord with its sibling validation-reference.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf page 12">
-
+    <sch:pattern id="fips-199"
+                 see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf page 12">
+                 
         <sch:title>Security Objectives Categorization (FIPS 199)</sch:title>
         <sch:rule context="oscal:system-characteristics">
             <!-- These should also be asserted in XML Schema -->
@@ -856,8 +904,9 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         value.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf page 11">
-
+    <sch:pattern id="sp800-60"
+                 see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf page 11">
+                 
         <sch:title>SP 800-60v2r1 Information Types:</sch:title>
         <sch:rule context="oscal:system-information">
             <sch:assert diagnostics="system-information-has-information-type-diagnostic"
@@ -941,7 +990,8 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         select element must have an approved value.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 13">
+    <sch:pattern id="sp800-63"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 13">
         <sch:title>Digital Identity Determination</sch:title>
         <sch:rule context="oscal:system-characteristics">
             <sch:assert diagnostics="has-security-eauth-level-diagnostic"
@@ -1240,7 +1290,7 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         have one function property.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern>
+    <sch:pattern id="basic-system-characteristics">
         <sch:rule context="oscal:system-implementation"
                   see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 62">
             <sch:assert diagnostics="has-system-component-diagnostic"


### PR DESCRIPTION
This PR defines Schematron phases in `ssp.sch'. No other changes are included.

This replaces #118.