### PR TITLE
Schematron for schematron and xspec

### DIFF
--- a/resources/validations/sch/sch.sch
+++ b/resources/validations/sch/sch.sch
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model schematypens="http://purl.oclc.org/dsdl/schematron" href="sch.sch" ?>
+<sch:schema
+    queryBinding="xslt2"
+    xmlns:doc="https://fedramp.gov/oscal/fedramp-automation-documentation"
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+    <sch:ns
+        prefix="sch"
+        uri="http://purl.oclc.org/dsdl/schematron" />
+
+    <sch:ns
+        prefix="doc"
+        uri="https://fedramp.gov/oscal/fedramp-automation-documentation" />
+
+    <sch:ns
+        prefix="x"
+        uri="http://www.jenitennison.com/xslt/xspec" />
+
+    <doc:xspec
+        href="sch.xspec" />
+
+    <sch:pattern>
+
+        <sch:rule
+            context="sch:schema">
+
+            <!-- report on related XSpec reference -->
+            <sch:report
+                id="xspec-defined-and-available"
+                role="information"
+                test="exists(doc:xspec/@href)">doc:xspec is defined and <sch:value-of
+                    select="doc:xspec/@href" /> is <sch:value-of
+                    select="
+                        if (doc-available(doc:xspec/@href)) then
+                            'available'
+                        else
+                            'unavailable'" />
+            </sch:report>
+
+            <!-- report on absolute XSpec path -->
+            <sch:report
+                id="xspec-resolved-uri"
+                role="information"
+                test="doc:xspec/@href"><sch:value-of
+                    select="doc:xspec/@href" /> resolves to <sch:value-of
+                    select="resolve-uri(doc:xspec/@href, base-uri())" />
+            </sch:report>
+
+            <!-- An Schematron document must have a reference to the corresponding XSpec document -->
+            <sch:assert
+                diagnostics="has-xspec-reference-diagnostic"
+                id="has-xspec-reference"
+                role="info"
+                test="doc:xspec/@href">Has reference <sch:value-of
+                    select="doc:xspec/@href" /> to XSpec document.</sch:assert>
+
+            <!-- The corresponding XSpec document must be available -->
+            <sch:assert
+                diagnostics="has-xspec-diagnostic"
+                id="has-xspec"
+                role="error"
+                test="doc:xspec/@href and doc-available(doc:xspec/@href)">Referenced XSpec document is available.</sch:assert>
+
+        </sch:rule>
+
+        <sch:rule
+            context="sch:assert | sch:report">
+
+            <sch:assert
+                diagnostics="has-id-attribute-diagnostic"
+                id="has-id-attribute"
+                role="error"
+                sqf:fix="add-id"
+                test="@id">Every Schematron assertion has an id.</sch:assert>
+
+            <sqf:fix
+                id="add-id">
+                <sqf:description>
+                    <sqf:title>Add the @id attribute</sqf:title>
+                </sqf:description>
+                <sqf:add
+                    node-type="attribute"
+                    target="id" />
+            </sqf:fix>
+
+            <sch:assert
+                diagnostics="has-role-attribute-diagnostic"
+                id="has-role-attribute"
+                role="warning"
+                sqf:fix="add-role"
+                test="@role">Every Schematron assertion has a role.</sch:assert>
+
+            <sqf:fix
+                id="add-role">
+                <sqf:description>
+                    <sqf:title>Add the @role attribute</sqf:title>
+                </sqf:description>
+                <sqf:add
+                    node-type="attribute"
+                    target="role" />
+            </sqf:fix>
+
+            <sch:assert
+                diagnostics="has-diagnostics-attribute-diagnostic"
+                id="has-diagnostics-attribute"
+                role="warning"
+                sqf:fix="add-diagnostics"
+                test="local-name() eq 'assert' and @diagnostics">Every Schematron assertion has diagnostics.</sch:assert>
+
+            <sqf:fix
+                id="add-diagnostics">
+                <sqf:description>
+                    <sqf:title>Add the @diagnostics attribute</sqf:title>
+                </sqf:description>
+                <sqf:add
+                    node-type="attribute"
+                    target="diagnostics" />
+            </sqf:fix>
+
+            <sch:let
+                name="xspec"
+                value="doc(/sch:schema/doc:xspec/@href)" />
+            <sch:assert
+                diagnostics="has-xspec-affirmative-test-diagnostic"
+                id="has-xspec-affirmative-test"
+                role="warning"
+                test="@id and doc(//doc:xspec/@href)//x:expect-not-assert[@id = current()/@id]">Every Schematron assertion has an XSpec test for the
+                affirmative assertion outcome.</sch:assert>
+            <sch:assert
+                diagnostics="has-xspec-negative-test-diagnostic"
+                id="has-xspec-negative-test"
+                role="warning"
+                test="@id and doc(//doc:xspec/@href)//x:expect-not-assert[@id = current()/@id]">Every Schematron assertion has an XSpec test for the
+                negative assertion outcome.</sch:assert>
+
+        </sch:rule>
+
+        <sch:rule
+            context="sch:assert | sch:report | sch:diagnostic">
+
+            <sch:assert
+                diagnostics="has-punctuation-diagnostic"
+                id="has-punctuation"
+                role="error"
+                sqf:fix="add-punctuation"
+                test="ends-with(., text()[last()])">Every Schematron assertion has a sentence which is terminated with a period.</sch:assert>
+
+            <sqf:fix
+                id="add-punctuation">
+                <sqf:description>
+                    <sqf:title>Add the required punctuation</sqf:title>
+                </sqf:description>
+                <sqf:stringReplace
+                    regex="$">.</sqf:stringReplace>
+            </sqf:fix>
+
+        </sch:rule>
+
+    </sch:pattern>
+
+    <sch:diagnostics>
+        <sch:diagnostic
+            id="xspec-defined-and-available-diagnostic">@href is likely missing or incorrect.</sch:diagnostic>
+        <sch:diagnostic
+            id="xspec-resolved-uri-diagnostic">@href is likely missing or incorrect.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-id-attribute-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" lacks the id attribute.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-role-attribute-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" lacks the role attribute.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-diagnostics-attribute-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" lacks the diagnostics attribute.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-punctuation-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" text does not end with a period.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-xspec-reference-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" lack an XSpec reference.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-xspec-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" referenced XSpec document is not available.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-xspec-affirmative-test-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" lacks an XSpec test for the affirmative assertion outcome.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-xspec-negative-test-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" lacks an XSpec test for the negative assertion outcome.</sch:diagnostic>
+        <sch:diagnostic
+            id="XPath">XPath: The context for this error is <sch:value-of
+                select="replace(path(), 'Q\{[^\{]+\}', '')" />.</sch:diagnostic>
+    </sch:diagnostics>
+
+</sch:schema>

--- a/resources/validations/sch/sch.sch
+++ b/resources/validations/sch/sch.sch
@@ -29,25 +29,25 @@
 
             <!-- report on related XSpec reference -->
             <sch:report
+                diagnostics="xspec-defined-and-available-diagnostic"
                 id="xspec-defined-and-available"
                 role="information"
-                test="exists(doc:xspec/@href)">doc:xspec is defined and <sch:value-of
+                test="doc:xspec/@href">doc:xspec is defined and <sch:value-of
                     select="doc:xspec/@href" /> is <sch:value-of
                     select="
                         if (doc-available(doc:xspec/@href)) then
                             'available'
                         else
-                            'unavailable'" />
-            </sch:report>
+                            'unavailable'" />. </sch:report>
 
             <!-- report on absolute XSpec path -->
             <sch:report
+                diagnostics="xspec-resolved-uri-diagnostic"
                 id="xspec-resolved-uri"
                 role="information"
                 test="doc:xspec/@href"><sch:value-of
                     select="doc:xspec/@href" /> resolves to <sch:value-of
-                    select="resolve-uri(doc:xspec/@href, base-uri())" />
-            </sch:report>
+                    select="resolve-uri(doc:xspec/@href, base-uri())" />. </sch:report>
 
             <!-- An Schematron document must have a reference to the corresponding XSpec document -->
             <sch:assert
@@ -108,7 +108,7 @@
                 id="has-diagnostics-attribute"
                 role="warning"
                 sqf:fix="add-diagnostics"
-                test="local-name() eq 'assert' and @diagnostics">Every Schematron assertion has diagnostics.</sch:assert>
+                test="local-name() eq 'report' or @diagnostics">Every Schematron assertion has diagnostics.</sch:assert>
 
             <sqf:fix
                 id="add-diagnostics">
@@ -163,9 +163,9 @@
 
     <sch:diagnostics>
         <sch:diagnostic
-            id="xspec-defined-and-available-diagnostic">@href is likely missing or incorrect.</sch:diagnostic>
+            id="xspec-defined-and-available-diagnostic">@href present and available.</sch:diagnostic>
         <sch:diagnostic
-            id="xspec-resolved-uri-diagnostic">@href is likely missing or incorrect.</sch:diagnostic>
+            id="xspec-resolved-uri-diagnostic">@href resolves.</sch:diagnostic>
         <sch:diagnostic
             id="has-id-attribute-diagnostic"><sch:value-of
                 select="name()" /> id="<sch:value-of

--- a/resources/validations/sch/sch.xspec
+++ b/resources/validations/sch/sch.xspec
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<x:description
+    schematron="../src/ssp/system-inventory.sch"
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+    <x:scenario
+        label="In FedRAMP OSCAL Schematron">
+        <x:scenario
+            label="For each Schematron assertion">
+            <x:context>
+                <sch:assert
+                    diagnostics="has-id-attribute-diagnostic"
+                    id="has-id-attribute"
+                    role="error"
+                    sqf:fix="add-id"
+                    test="@id">Has id.</sch:assert>
+            </x:context>
+            <x:scenario
+                label="when the id attribute is present">
+                <x:expect-not-assert
+                    id="has-id-attribute"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="when the role attribute is present">
+                <x:expect-not-assert
+                    id="has-role-attribute"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="when the diagnostics attribute is present">
+                <x:expect-not-assert
+                    id="has-diagnostics-attribute"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="when the punctuation is correct">
+                <x:expect-not-assert
+                    id="has-punctuation"
+                    label="that is correct" />
+            </x:scenario>
+
+            <x:scenario
+                label="when the XSpec reference is present">
+                <x:expect-not-assert
+                    id="has-xspec-reference"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="when the XSpec reference document is available">
+                <x:expect-not-assert
+                    id="has-xspec"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="when the punctuation is correct">
+                <x:expect-not-assert
+                    id="has-xspec-test"
+                    label="that is correct" />
+            </x:scenario>
+
+        </x:scenario>
+
+    </x:scenario>
+
+</x:description>

--- a/resources/validations/sch/xspec.sch
+++ b/resources/validations/sch/xspec.sch
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model schematypens="http://purl.oclc.org/dsdl/schematron" href="sch.sch" ?>
+<sch:schema
+    queryBinding="xslt2"
+    xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+    xmlns:sqf="http://www.schematron-quickfix.com/validator/process"
+    xmlns:x="http://www.jenitennison.com/xslt/xspec">
+
+    <sch:ns
+        prefix="sch"
+        uri="http://purl.oclc.org/dsdl/schematron" />
+
+    <sch:ns
+        prefix="x"
+        uri="http://www.jenitennison.com/xslt/xspec" />
+
+    <sch:pattern>
+
+        <sch:rule
+            context="x:description">
+
+            <sch:report
+                role="information"
+                test="true()"><sch:value-of
+                    select="/x:description/@schematron" /> is <sch:value-of
+                    select="
+                        if (doc-available(/x:description/@schematron)) then
+                            'available'
+                        else
+                            'unavailable'" /></sch:report>
+
+            <sch:assert
+                test="doc-available(@schematron)">Schematron document is available.</sch:assert>
+
+            <sch:report
+                test="true()"><sch:value-of
+                    select="/x:description/@schematron" /> has assertions <sch:value-of
+                    select="doc(/x:description/@schematron)//sch:assert/@id" /></sch:report>
+
+            <sch:report
+                test="true()">
+                <sch:value-of
+                    select="count(doc(/x:description/@schematron)//sch:assert/@id)" /> assertions; <sch:value-of
+                    select="count(//x:expect-not-assert/@id)" /> affirmative tests; <sch:value-of
+                    select="count(//x:expect-assert/@id)" /> negative tests</sch:report>
+
+            <sch:assert
+                diagnostics="missing-affirmative-test"
+                id="has-affirmative-tests"
+                test="
+                    every $id in doc(/x:description/@schematron)//sch:assert/@id
+                        satisfies $id = //x:expect-not-assert/@id">Every Schematron assertion has a counterpart affirmative
+                test</sch:assert>
+
+            <sch:assert
+                diagnostics="missing-negative-test"
+                id="has-negative-test"
+                test="
+                    every $id in doc(/x:description/@schematron)//sch:assert/@id
+                        satisfies $id = //x:expect-assert/@id">Every Schematron assertion has a counterpart negative test</sch:assert>
+
+        </sch:rule>
+
+    </sch:pattern>
+
+    <sch:diagnostics>
+        <sch:diagnostic
+            id="missing-affirmative-test">The following <sch:value-of
+                select="
+                    count(doc(/x:description/@schematron)//sch:assert[current()/@id != //x:expect-not-assert/@id]/@id)" /> assertions lack an affirmative test: <sch:value-of
+                        select="for $id in doc(/x:description/@schematron)//sch:assert/@id return if ($id != //x:expect-not-assert/@id) then $id else ''
+                    " /></sch:diagnostic>
+        <sch:diagnostic
+            id="missing-negative-test">The following assertions lack a negative test: <sch:value-of
+                select="
+                    doc(/x:description/@schematron)//sch:assert[
+                    not(current()/@id = //x:expect-assert/@id)
+                    ]/@id" /></sch:diagnostic>
+    </sch:diagnostics>
+
+</sch:schema>


### PR DESCRIPTION
This is Schematron to constrain Schematron and XSpec written for SSP validation to exhibit desired quality and form.