### PR TITLE
Add references to documentation and checklist

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -269,11 +269,15 @@
                         role="fatal"
                         test="count($registry/f:fedramp-values/f:value-set) &gt; 0">The registry values are available.</sch:assert>
             <sch:assert diagnostics="no-security-sensitivity-level-diagnostic"
+                        doc:checklist-reference="Section C Check 1.a"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.2"
                         doc:organizational-id="section-c.1.a"
                         id="no-security-sensitivity-level"
                         role="fatal"
                         test="$sensitivity-level != ''">[Section C Check 1.a] Sensitivity level is defined.</sch:assert>
             <sch:assert diagnostics="invalid-security-sensitivity-level-diagnostic"
+                        doc:checklist-reference="Section C Check 1.a"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.2"
                         doc:organizational-id="section-c.1.a"
                         id="invalid-security-sensitivity-level"
                         role="fatal"
@@ -281,13 +285,15 @@
                         value.</sch:assert>
             <sch:let name="implemented"
                      value="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:statement" />
-            <sch:report id="implemented-response-points"
+            <sch:report doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
+                        id="implemented-response-points"
                         role="information"
                         test="exists($implemented)">[Section C Check 2] This SSP has implemented a statement for each of the following lettered
                         response points for required controls: 
             <sch:value-of select="$implemented/@statement-id" />.</sch:report>
         </sch:rule>
-        <sch:rule context="/o:system-security-plan/o:control-implementation">
+        <sch:rule context="/o:system-security-plan/o:control-implementation"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5">
             <sch:let name="registry-ns"
                      value="$registry/f:fedramp-values/f:namespace/f:ns/@ns" />
             <sch:let name="sensitivity-level"
@@ -306,7 +312,8 @@
                      value="$required-controls[o:prop[@name = 'CORE' and @ns = $registry-ns] and @id = $all-missing/@id]" />
             <sch:let name="extraneous"
                      value="$implemented[not(@control-id = $required-controls/@id)]" />
-            <sch:report id="each-required-control-report"
+            <sch:report doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
+                        id="each-required-control-report"
                         role="information"
                         test="count($required-controls) &gt; 0">The following 
             <sch:value-of select="count($required-controls)" />
@@ -317,16 +324,22 @@
                             ' controls'" />are required: 
             <sch:value-of select="$required-controls/@id" />.</sch:report>
             <sch:assert diagnostics="incomplete-core-implemented-requirements-diagnostic"
+                        doc:checklist-reference="Section C Check 3"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-c.3"
                         id="incomplete-core-implemented-requirements"
                         role="error"
                         test="not(exists($core-missing))">[Section C Check 3] This SSP has implemented the most important controls.</sch:assert>
             <sch:assert diagnostics="incomplete-all-implemented-requirements-diagnostic"
+                        doc:checklist-reference="Section C Check 2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-c.2"
                         id="incomplete-all-implemented-requirements"
                         role="warning"
                         test="not(exists($all-missing))">[Section C Check 2] This SSP has implemented all required controls.</sch:assert>
             <sch:assert diagnostics="extraneous-implemented-requirements-diagnostic"
+                        doc:checklist-reference="Section C Check 2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-c.2"
                         id="extraneous-implemented-requirements"
                         role="warning"
@@ -335,7 +348,8 @@
                      value="$ok-values =&gt; lv:analyze(//o:implemented-requirement/o:prop[@name = 'implementation-status'])" />
             <sch:let name="total"
                      value="$results/reports/@count" />
-            <sch:report id="control-implemented-requirements-stats"
+            <sch:report doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
+                        id="control-implemented-requirements-stats"
                         role="information"
                         test="count($results/errors/error) = 0">
             <sch:value-of select="$results =&gt; lv:report() =&gt; normalize-space()" />.</sch:report>
@@ -358,11 +372,15 @@
             <sch:let name="missing"
                      value="$required-response-points[not(@id = $implemented/@statement-id)]" />
             <sch:assert diagnostics="invalid-implementation-status-diagnostic"
+                        doc:checklist-reference="Section C Check 2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-c.2"
                         id="invalid-implementation-status"
                         role="error"
                         test="not(exists($corrections))">[Section C Check 2] Implementation status is correct.</sch:assert>
             <sch:assert diagnostics="missing-response-points-diagnostic"
+                        doc:checklist-reference="Section C Check 2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-c.2"
                         id="missing-response-points"
                         role="error"
@@ -380,6 +398,8 @@
             <sch:let name="remarks-length"
                      value="$remarks =&gt; string-length()" />
             <sch:assert diagnostics="missing-response-components-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="missing-response-components"
                         role="warning"
@@ -388,6 +408,8 @@
         </sch:rule>
         <sch:rule context="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:statement/o:description">
             <sch:assert diagnostics="extraneous-response-description-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="extraneous-response-description"
                         role="warning"
@@ -395,6 +417,8 @@
         </sch:rule>
         <sch:rule context="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:statement/o:remarks">
             <sch:assert diagnostics="extraneous-response-remarks-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="extraneous-response-remarks"
                         role="warning"
@@ -404,12 +428,16 @@
             <sch:let name="component-ref"
                      value="./@component-uuid" />
             <sch:assert diagnostics="invalid-component-match-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="invalid-component-match"
                         role="warning"
                         test="/o:system-security-plan/o:system-implementation/o:component[@uuid = $component-ref] =&gt; exists()">[Section D Checks]
                         Response statement cites a component in the system implementation inventory.</sch:assert>
             <sch:assert diagnostics="missing-component-description-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="missing-component-description"
                         role="error"
@@ -424,6 +452,8 @@
             <sch:let name="description-length"
                      value="$description =&gt; string-length()" />
             <sch:assert diagnostics="incomplete-response-description-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="incomplete-response-description"
                         role="error"
@@ -438,6 +468,8 @@
             <sch:let name="remarks-length"
                      value="$remarks =&gt; string-length()" />
             <sch:assert diagnostics="incomplete-response-remarks-diagnostic"
+                        doc:checklist-reference="Section D Checks"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5"
                         doc:organizational-id="section-d"
                         id="incomplete-response-remarks"
                         role="warning"
@@ -456,12 +488,16 @@
             <sch:let name="extraneous-parties"
                      value="$responsible-parties[not(o:party-uuid = $parties/@uuid)]" />
             <sch:assert diagnostics="incorrect-role-association-diagnostic"
+                        doc:checklist-reference="Section C Check 2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         doc:organizational-id="section-c.6"
                         id="incorrect-role-association"
                         role="error"
                         test="not(exists($extraneous-roles))">[Section C Check 2] This SSP has defined a responsible party with no extraneous
                         roles.</sch:assert>
             <sch:assert diagnostics="incorrect-party-association-diagnostic"
+                        doc:checklist-reference="Section C Check 2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         doc:organizational-id="section-c.6"
                         id="incorrect-party-association"
                         role="error"
@@ -470,6 +506,7 @@
         </sch:rule>
         <sch:rule context="/o:system-security-plan/o:back-matter/o:resource">
             <sch:assert diagnostics="resource-uuid-required-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         doc:organizational-id="section-b.?????"
                         id="resource-uuid-required"
                         role="error"
@@ -486,17 +523,20 @@
                 test="doc-available(./@href)">This SSP references back-matter resource: <sch:value-of
                     select="./@href" /></sch:assert>
         </sch:rule>-->
-        <sch:rule context="/o:system-security-plan/o:back-matter/o:resource/o:base64">
+        <sch:rule context="/o:system-security-plan/o:back-matter/o:resource/o:base64"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP Content §4.10">
             <sch:let name="filename"
                      value="@filename" />
             <sch:let name="media-type"
                      value="@media-type" />
             <sch:assert diagnostics="resource-base64-available-filename-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP Content §4.10"
                         doc:organizational-id="section-b.?????"
                         id="resource-base64-available-filename"
                         role="error"
                         test="./@filename">This base64 has a filename attribute.</sch:assert>
             <sch:assert diagnostics="resource-base64-available-media-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP Content §4.10"
                         doc:organizational-id="section-b.?????"
                         id="resource-base64-available-media-type"
                         role="error"
@@ -512,34 +552,42 @@
         <sch:title>Basic resource constraints</sch:title>
         <sch:let name="attachment-types"
                  value="$fedramp-values//fedramp:value-set[@name = 'attachment-type']//fedramp:enum/@value" />
-        <sch:rule context="oscal:resource">
+        <sch:rule context="oscal:resource"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6">
             <!-- the following assertion recapitulates the XML Schema constraint -->
             <sch:assert diagnostics="resource-has-uuid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="resource-has-uuid"
                         role="error"
                         test="@uuid">A resource must have a uuid attribute.</sch:assert>
             <sch:assert diagnostics="resource-has-title-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="resource-has-title"
                         role="warning"
                         test="oscal:title">A resource should have a title.</sch:assert>
             <sch:assert diagnostics="resource-has-rlink-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="resource-has-rlink"
                         role="error"
                         test="oscal:rlink">A resource must have a rlink element</sch:assert>
             <sch:assert diagnostics="resource-is-referenced-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="resource-is-referenced"
                         role="information"
                         test="@uuid = (//@href[matches(., '^#')] ! substring-after(., '#'))">A resource should be referenced from within the
                         document.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:back-matter/oscal:resource/oscal:prop[@name = 'type']">
+        <sch:rule context="oscal:back-matter/oscal:resource/oscal:prop[@name = 'type']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1">
             <sch:assert diagnostics="attachment-type-is-valid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="attachment-type-is-valid"
                         role="warning"
                         test="@value = $attachment-types">A resource should have an allowed attachment-type property.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:back-matter/oscal:resource/oscal:rlink">
             <sch:assert diagnostics="rlink-has-href-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="rlink-has-href"
                         role="error"
                         test="@href">A resource rlink must have an href attribute.</sch:assert>
@@ -551,6 +599,7 @@
                 test="$WARNING and @media-type">the &lt;<sch:name/>&gt; element should have a media-type attribute</sch:assert>-->
         </sch:rule>
         <sch:rule context="oscal:rlink | oscal:base64"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                   role="error">
             <sch:let name="media-types"
                      value="$fedramp-values//fedramp:value-set[@name = 'media-type']//fedramp:enum/@value" />
@@ -558,33 +607,42 @@
                         test="false()">There are 
             <sch:value-of select="count($media-types)" />media types.</sch:report>-->
             <sch:assert diagnostics="has-allowed-media-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="has-allowed-media-type"
                         role="error"
                         test="@media-type = $media-types">A media-type attribute must have an allowed value.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="base64">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
+                 id="base64">
         <sch:title>base64 attachments</sch:title>
-        <sch:rule context="oscal:back-matter/oscal:resource">
+        <sch:rule context="oscal:back-matter/oscal:resource"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1">
             <sch:assert diagnostics="resource-has-base64-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="resource-has-base64"
                         role="warning"
                         test="oscal:base64">A resource should have a base64 element.</sch:assert>
             <sch:assert diagnostics="resource-base64-cardinality-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="resource-has-base64-cardinality"
                         role="error"
                         test="not(oscal:base64[2])">A resource must have only one base64 element.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:back-matter/oscal:resource/oscal:base64">
+        <sch:rule context="oscal:back-matter/oscal:resource/oscal:base64"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1">
             <sch:assert diagnostics="base64-has-filename-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="base64-has-filename"
                         role="error"
                         test="@filename">A base64 element must have a filename attribute.</sch:assert>
             <sch:assert diagnostics="base64-has-media-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="base64-has-media-type"
                         role="error"
                         test="@media-type">A base64 element must have a media-type attribute.</sch:assert>
             <sch:assert diagnostics="base64-has-content-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.1"
                         id="base64-has-content"
                         role="error"
                         test="matches(normalize-space(), '^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=)?$')">A
@@ -595,62 +653,81 @@
     <sch:pattern id="specific-attachments">
         <sch:title>Constraints for specific attachments</sch:title>
         <sch:rule context="oscal:back-matter"
+                  doc:guide-reference="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf"
                   see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf">
             <sch:assert diagnostics="has-fedramp-acronyms-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP Content §4.8"
                         id="has-fedramp-acronyms"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'fedramp-acronyms']]">A
                         FedRAMP OSCAL SSP must have the FedRAMP Master Acronym and Glossary attached.</sch:assert>
             <sch:assert diagnostics="has-fedramp-citations-diagnostic"
                         doc:attachment="§15 Attachment 12"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP Content §4.10"
                         id="has-fedramp-citations"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'fedramp-citations']]">
                         [Section B Check 3.12] A FedRAMP OSCAL SSP must have the FedRAMP Applicable Laws and Regulations attached.</sch:assert>
             <sch:assert diagnostics="has-fedramp-logo-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP Content §4.1"
                         id="has-fedramp-logo"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'fedramp-logo']]">A
                         FedRAMP OSCAL SSP must have the FedRAMP Logo attached.</sch:assert>
             <sch:assert diagnostics="has-user-guide-diagnostic"
                         doc:attachment="§15 Attachment 2"
+                        doc:checklist-reference="Section B Check 3.2"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-user-guide"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'user-guide']]">[Section
                         B Check 3.2] A FedRAMP OSCAL SSP must have a User Guide attached.</sch:assert>
             <sch:assert diagnostics="has-rules-of-behavior-diagnostic"
                         doc:attachment="§15 Attachment 5"
+                        doc:checklist-reference="Section B Check 3.5"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-rules-of-behavior"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'rules-of-behavior']]">
                         [Section B Check 3.5] A FedRAMP OSCAL SSP must have Rules of Behavior.</sch:assert>
             <sch:assert diagnostics="has-information-system-contingency-plan-diagnostic"
                         doc:attachment="§15 Attachment 6"
+                        doc:checklist-reference="Section B Check 3.6"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-information-system-contingency-plan"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'information-system-contingency-plan']]">
             [Section B Check 3.6] A FedRAMP OSCAL SSP must have a Contingency Plan attached.</sch:assert>
             <sch:assert diagnostics="has-configuration-management-plan-diagnostic"
                         doc:attachment="§15 Attachment 7"
+                        doc:checklist-reference="Section B Check 3.7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-configuration-management-plan"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'configuration-management-plan']]">
                         [Section B Check 3.7] A FedRAMP OSCAL SSP must have a Configuration Management Plan attached.</sch:assert>
             <sch:assert diagnostics="has-incident-response-plan-diagnostic"
                         doc:attachment="§15 Attachment 8"
+                        doc:checklist-reference="Section B Check 3.8"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-incident-response-plan"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'incident-response-plan']]">
                         [Section B Check 3.8] A FedRAMP OSCAL SSP must have an Incident Response Plan attached.</sch:assert>
+            <!-- Section B Check 3.9 is not used -->
+            <!-- Section B Check 3.10 is not used -->
             <sch:assert diagnostics="has-separation-of-duties-matrix-diagnostic"
                         doc:attachment="§15 Attachment 11"
+                        doc:checklist-reference="Section B Check 3.11"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-separation-of-duties-matrix"
                         role="error"
                         test="oscal:resource[oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'type' and @value = 'separation-of-duties-matrix']]">
                         [Section B Check 3.11] A FedRAMP OSCAL SSP must have a Separation of Duties Matrix attached.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="policy-and-procedure">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
+                 id="policy-and-procedure">
         <sch:title>Policy and Procedure attachments</sch:title>
         <sch:title>A FedRAMP SSP must incorporate one policy document and one procedure document for each of the 17 NIST SP 800-54 Revision 4 control
         families</sch:title>
@@ -658,8 +735,11 @@
         <!-- FIXME: XSpec testing malfunctions when the following rule context is constrained to XX-1 control-ids -->
         <sch:rule context="oscal:implemented-requirement[matches(@control-id, '^[a-z]{2}-1$')]"
                   doc:attachment="§15 Attachment 1"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 48">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6">
             <sch:assert diagnostics="has-policy-link-diagnostic"
+                        doc:checklist-reference="Section B Check 3.1"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-policy-link"
                         role="error"
                         test="descendant::oscal:by-component/oscal:link[@rel = 'policy']">[Section B Check 3.1] A FedRAMP SSP must incorporate a
@@ -667,6 +747,8 @@
             <sch:let name="policy-hrefs"
                      value="distinct-values(descendant::oscal:by-component/oscal:link[@rel = 'policy']/@href ! substring-after(., '#'))" />
             <sch:assert diagnostics="has-policy-attachment-resource-diagnostic"
+                        doc:checklist-reference="Section B Check 3.1"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-policy-attachment-resource"
                         role="error"
                         test="
@@ -675,6 +757,8 @@
 FedRAMP SSP must incorporate a policy document for each of the 17 NIST SP 800-54 Revision 4 control families.</sch:assert>
             <!-- TODO: ensure resource has an rlink -->
             <sch:assert diagnostics="has-procedure-link-diagnostic"
+                        doc:checklist-reference="Section B Check 3.1"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-procedure-link"
                         role="error"
                         test="descendant::oscal:by-component/oscal:link[@rel = 'procedure']">[Section B Check 3.1] A FedRAMP SSP must incorporate a
@@ -682,6 +766,8 @@ FedRAMP SSP must incorporate a policy document for each of the 17 NIST SP 800-54
             <sch:let name="procedure-hrefs"
                      value="distinct-values(descendant::oscal:by-component/oscal:link[@rel = 'procedure']/@href ! substring-after(., '#'))" />
             <sch:assert diagnostics="has-procedure-attachment-resource-diagnostic"
+                        doc:checklist-reference="Section B Check 3.1"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6"
                         id="has-procedure-attachment-resource"
                         role="error"
                         test="
@@ -691,7 +777,9 @@ FedRAMP SSP must incorporate a policy document for each of the 17 NIST SP 800-54
 A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 800-54 Revision 4 control families.</sch:assert>
             <!-- TODO: ensure resource has an rlink -->
         </sch:rule>
-        <sch:rule context="oscal:by-component/oscal:link[@rel = ('policy', 'procedure')]">
+        <sch:rule context="oscal:by-component/oscal:link[@rel = ('policy', 'procedure')]"
+                  doc:checklist-reference="Section B Check 3.1"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6">
             <sch:let name="ir"
                      value="ancestor::oscal:implemented-requirement" />
             <sch:report diagnostics="has-reuse-diagnostic"
@@ -706,18 +794,25 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
     <sch:pattern id="privacy1">
         <sch:title>A FedRAMP OSCAL SSP must specify a Privacy Point of Contact</sch:title>
         <sch:rule context="oscal:metadata"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 50">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.2"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.2">
             <sch:assert diagnostics="has-privacy-poc-role-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.2"
                         id="has-privacy-poc-role"
                         role="error"
                         test="/oscal:system-security-plan/oscal:metadata/oscal:role[@id = 'privacy-poc']">[Section B Check 3.4] A FedRAMP OSCAL SSP
                         must incorporate a Privacy Point of Contact role.</sch:assert>
             <sch:assert diagnostics="has-responsible-party-privacy-poc-role-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.2"
                         id="has-responsible-party-privacy-poc-role"
                         role="error"
                         test="/oscal:system-security-plan/oscal:metadata/oscal:responsible-party[@role-id = 'privacy-poc']">[Section B Check 3.4] A
                         FedRAMP OSCAL SSP must declare a Privacy Point of Contact responsible party role reference.</sch:assert>
             <sch:assert diagnostics="has-responsible-privacy-poc-party-uuid-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.2"
                         id="has-responsible-privacy-poc-party-uuid"
                         role="error"
                         test="/oscal:system-security-plan/oscal:metadata/oscal:responsible-party[@role-id = 'privacy-poc']/oscal:party-uuid">[Section
@@ -726,6 +821,8 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             <sch:let name="poc-uuid"
                      value="/oscal:system-security-plan/oscal:metadata/oscal:responsible-party[@role-id = 'privacy-poc']/oscal:party-uuid" />
             <sch:assert diagnostics="has-privacy-poc-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.2"
                         id="has-privacy-poc"
                         role="error"
                         test="/oscal:system-security-plan/oscal:metadata/oscal:party[@uuid = $poc-uuid]">[Section B Check 3.4] A FedRAMP OSCAL SSP
@@ -736,45 +833,61 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
         <sch:title>A FedRAMP OSCAL SSP may need to incorporate a PIA and possibly a SORN</sch:title>
         <!-- The "PTA" appears to be just a few questions, not an attachment -->
         <sch:rule context="oscal:prop[@name = 'privacy-sensitive'] | oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and matches(@name, '^pta-\d$')]"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 52">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4">
             <sch:assert diagnostics="has-correct-yes-or-no-answer-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-correct-yes-or-no-answer"
                         role="error"
                         test="current()/@value = ('yes', 'no')">[Section B Check 3.4] A Privacy Threshold Analysis (PTA)/Privacy Impact Analysis
                         (PIA) qualifying question must have an allowed answer.</sch:assert>
         </sch:rule>
         <sch:rule context="/oscal:system-security-plan/oscal:system-characteristics/oscal:system-information"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 52">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4">
             <sch:assert diagnostics="has-privacy-sensitive-designation-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-privacy-sensitive-designation"
                         role="error"
                         test="oscal:prop[@name = 'privacy-sensitive']">[Section B Check 3.4] A FedRAMP OSCAL SSP must have a privacy-sensitive
                         designation.</sch:assert>
             <sch:assert diagnostics="has-pta-question-1-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-pta-question-1"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = 'pta-1']">[Section B Check 3.4] A
                         FedRAMP OSCAL SSP must have Privacy Threshold Analysis (PTA)/Privacy Impact Analysis (PIA) qualifying question
                         #1.</sch:assert>
             <sch:assert diagnostics="has-pta-question-2-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-pta-question-2"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = 'pta-2']">[Section B Check 3.4] A
                         FedRAMP OSCAL SSP must have Privacy Threshold Analysis (PTA)/Privacy Impact Analysis (PIA) qualifying question
                         #2.</sch:assert>
             <sch:assert diagnostics="has-pta-question-3-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-pta-question-3"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = 'pta-3']">[Section B Check 3.4] A
                         FedRAMP OSCAL SSP must have Privacy Threshold Analysis (PTA)/Privacy Impact Analysis (PIA) qualifying question
                         #3.</sch:assert>
             <sch:assert diagnostics="has-pta-question-4-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-pta-question-4"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = 'pta-4']">[Section B Check 3.4] A
                         FedRAMP OSCAL SSP must have Privacy Threshold Analysis (PTA)/Privacy Impact Analysis (PIA) qualifying question
                         #4.</sch:assert>
             <sch:assert diagnostics="has-all-pta-questions-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-all-pta-questions"
                         role="error"
                         test="
@@ -782,6 +895,8 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         satisfies exists(oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = $name])">[Section B Check
 3.4] A FedRAMP OSCAL SSP must have all four PTA questions.</sch:assert>
             <sch:assert diagnostics="has-correct-pta-question-cardinality-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-correct-pta-question-cardinality"
                         role="error"
                         test="
@@ -789,14 +904,19 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                         satisfies exists(oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = $name][2]))">[Section B Check
 3.4] A FedRAMP OSCAL SSP must have no duplicate PTA questions.</sch:assert>
             <sch:assert diagnostics="has-sorn-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-sorn"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = 'pta-4' and @value = 'yes'] and oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'pta' and @name = 'sorn-id' (: and @value != '':)]">
             [Section B Check 3.4] A FedRAMP OSCAL SSP may have a SORN ID.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:back-matter"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 52">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4">
             <sch:assert diagnostics="has-pia-diagnostic"
+                        doc:checklist-reference="Section B Check 3.4"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.4"
                         id="has-pia"
                         role="error"
                         test="
@@ -805,95 +925,117 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             [Section B Check 3.4] This FedRAMP OSCAL SSP must incorporate a Privacy Impact Analysis.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="fips-140"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 64">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
+                 id="fips-140"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A">
         <!-- FIXME: Draft guide is wildly different than template -->
         <sch:title>FIPS 140 Validation</sch:title>
-        <sch:rule context="oscal:system-implementation">
+        <sch:rule context="oscal:system-implementation"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A">
             <sch:assert diagnostics="has-CMVP-validation-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-CMVP-validation"
                         role="error"
                         test="oscal:component[@type = 'validation']">A FedRAMP OSCAL SSP must incorporate one or more FIPS 140 validated
                         modules.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:component[@type = 'validation']">
+        <sch:rule context="oscal:component[@type = 'validation']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A">
             <sch:assert diagnostics="has-CMVP-validation-reference-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-CMVP-validation-reference"
                         role="error"
                         test="oscal:prop[@name = 'validation-reference']">A validation component or inventory-item must have a validation-reference
                         property.</sch:assert>
             <sch:assert diagnostics="has-CMVP-validation-details-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-CMVP-validation-details"
                         role="error"
                         test="oscal:link[@rel = 'validation-details']">A validation component or inventory-item must have a validation-details
                         link.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'validation-reference']">
+        <sch:rule context="oscal:prop[@name = 'validation-reference']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A">
             <sch:assert diagnostics="has-credible-CMVP-validation-reference-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-credible-CMVP-validation-reference"
                         role="error"
                         test="matches(@value, '^\d{3,4}$')">A validation-reference property must provide a CMVP certificate number.</sch:assert>
             <sch:assert diagnostics="has-consonant-CMVP-validation-reference-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-consonant-CMVP-validation-reference"
                         role="error"
                         test="@value = tokenize(following-sibling::oscal:link[@rel = 'validation-details']/@href, '/')[last()]">A
                         validation-reference property must be in accord with its sibling validation-details href.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:link[@rel = 'validation-details']">
+        <sch:rule context="oscal:link[@rel = 'validation-details']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A">
             <sch:assert diagnostics="has-credible-CMVP-validation-details-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-credible-CMVP-validation-details"
                         role="error"
                         test="matches(@href, '^https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/\d{3,4}$')">A
                         validation-details link must refer to a NIST CMVP certificate detail page.</sch:assert>
             <sch:assert diagnostics="has-consonant-CMVP-validation-details-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                         id="has-consonant-CMVP-validation-details"
                         role="error"
                         test="tokenize(@href, '/')[last()] = preceding-sibling::oscal:prop[@name = 'validation-reference']/@value">A
                         validation-details link must be in accord with its sibling validation-reference.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="fips-199"
-                 see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf page 12">
-                 
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
+                 id="fips-199"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4">
         <sch:title>Security Objectives Categorization (FIPS 199)</sch:title>
-        <sch:rule context="oscal:system-characteristics">
+        <sch:rule context="oscal:system-characteristics"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4">
             <!-- These should also be asserted in XML Schema -->
             <sch:assert diagnostics="has-security-sensitivity-level-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-security-sensitivity-level"
                         role="error"
                         test="oscal:security-sensitivity-level">A FedRAMP OSCAL SSP must specify a FIPS 199 categorization.</sch:assert>
             <sch:assert diagnostics="has-security-impact-level-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-security-impact-level"
                         role="error"
                         test="oscal:security-impact-level">A FedRAMP OSCAL SSP must specify a security impact level.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:security-sensitivity-level">
+        <sch:rule context="oscal:security-sensitivity-level"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4">
             <sch:let name="security-sensitivity-levels"
                      value="$fedramp-values//fedramp:value-set[@name = 'security-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-security-sensitivity-level-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-allowed-security-sensitivity-level"
                         role="error"
                         test="current() = $security-sensitivity-levels">A FedRAMP OSCAL SSP must specify an allowed
                         security-sensitivity-level.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:security-impact-level">
+        <sch:rule context="oscal:security-impact-level"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4">
             <!-- These should also be asserted in XML Schema -->
             <sch:assert diagnostics="has-security-objective-confidentiality-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-security-objective-confidentiality"
                         role="error"
                         test="oscal:security-objective-confidentiality">A FedRAMP OSCAL SSP must specify a confidentiality security
                         objective.</sch:assert>
             <sch:assert diagnostics="has-security-objective-integrity-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-security-objective-integrity"
                         role="error"
                         test="oscal:security-objective-integrity">A FedRAMP OSCAL SSP must specify an integrity security objective.</sch:assert>
             <sch:assert diagnostics="has-security-objective-availability-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-security-objective-availability"
                         role="error"
                         test="oscal:security-objective-availability">A FedRAMP OSCAL SSP must specify an availability security
                         objective.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:security-objective-confidentiality | oscal:security-objective-integrity | oscal:security-objective-availability">
+        <sch:rule context="oscal:security-objective-confidentiality | oscal:security-objective-integrity | oscal:security-objective-availability"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4">
             <sch:let name="security-objective-levels"
                      value="$fedramp-values//fedramp:value-set[@name = 'security-level']//fedramp:enum/@value" />
             <!--<sch:report role="information"
@@ -901,302 +1043,371 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             <sch:value-of select="count($security-objective-levels)" />security-objective-levels: 
             <sch:value-of select="string-join($security-objective-levels, ' ∨ ')" />.</sch:report>-->
             <sch:assert diagnostics="has-allowed-security-objective-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.4"
                         id="has-allowed-security-objective-value"
                         role="error"
                         test="current() = $security-objective-levels">A FedRAMP OSCAL SSP must specify an allowed security objective
                         value.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="sp800-60"
-                 see="https://github.com/18F/fedramp-automation/blob/master/documents/Guide_to_OSCAL-based_FedRAMP_System_Security_Plans_(SSP).pdf page 11">
-                 
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
+                 id="sp800-60"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
         <sch:title>SP 800-60v2r1 Information Types:</sch:title>
-        <sch:rule context="oscal:system-information">
+        <sch:rule context="oscal:system-information"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
             <sch:assert diagnostics="system-information-has-information-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="system-information-has-information-type"
                         role="error"
                         test="oscal:information-type">A FedRAMP OSCAL SSP must specify at least one information-type.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:information-type">
+        <sch:rule context="oscal:information-type"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
             <sch:assert diagnostics="information-type-has-title-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="information-type-has-title"
                         role="error"
                         test="oscal:title">A FedRAMP OSCAL SSP information-type must have a title.</sch:assert>
             <sch:assert diagnostics="information-type-has-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="information-type-has-description"
                         role="error"
                         test="oscal:description">A FedRAMP OSCAL SSP information-type must have a description.</sch:assert>
             <sch:assert diagnostics="information-type-has-categorization-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="information-type-has-categorization"
                         role="error"
                         test="oscal:categorization">A FedRAMP OSCAL SSP information-type must have at least one categorization.</sch:assert>
             <sch:assert diagnostics="information-type-has-confidentiality-impact-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="information-type-has-confidentiality-impact"
                         role="error"
                         test="oscal:confidentiality-impact">A FedRAMP OSCAL SSP information-type must have a confidentiality-impact.</sch:assert>
             <sch:assert diagnostics="information-type-has-integrity-impact-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="information-type-has-integrity-impact"
                         role="error"
                         test="oscal:integrity-impact">A FedRAMP OSCAL SSP information-type must have a integrity-impact.</sch:assert>
             <sch:assert diagnostics="information-type-has-availability-impact-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="information-type-has-availability-impact"
                         role="error"
                         test="oscal:availability-impact">A FedRAMP OSCAL SSP information-type must have a availability-impact.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:categorization">
+        <sch:rule context="oscal:categorization"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
             <sch:assert diagnostics="categorization-has-system-attribute-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="categorization-has-system-attribute"
                         role="error"
                         test="@system">A FedRAMP OSCAL SSP information-type categorization must have a system attribute.</sch:assert>
             <sch:assert diagnostics="categorization-has-correct-system-attribute-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="categorization-has-correct-system-attribute"
                         role="error"
                         test="@system = 'https://doi.org/10.6028/NIST.SP.800-60v2r1'">A FedRAMP OSCAL SSP information-type categorization must have a
                         correct system attribute.</sch:assert>
             <sch:assert diagnostics="categorization-has-information-type-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="categorization-has-information-type-id"
                         role="error"
                         test="oscal:information-type-id">A FedRAMP OSCAL SSP information-type categorization must have at least one
                         information-type-id.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:information-type-id">
+        <sch:rule context="oscal:information-type-id"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
             <sch:let name="information-types"
                      value="doc(concat($registry-base-path, '/information-types.xml'))//fedramp:information-type/@id" />
             <!-- note the variant namespace and associated prefix -->
             <sch:assert diagnostics="has-allowed-information-type-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="has-allowed-information-type-id"
                         role="error"
                         test="current()[. = $information-types]">A FedRAMP OSCAL SSP information-type-id must have a SP 800-60v2r1
                         identifier.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:confidentiality-impact | oscal:integrity-impact | oscal:availability-impact">
+        <sch:rule context="oscal:confidentiality-impact | oscal:integrity-impact | oscal:availability-impact"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
             <sch:assert diagnostics="cia-impact-has-base-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="cia-impact-has-base"
                         role="error"
                         test="oscal:base">A FedRAMP OSCAL SSP information-type confidentiality-, integrity-, or availability-impact must have a base
                         element.</sch:assert>
             <sch:assert diagnostics="cia-impact-has-selected-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="cia-impact-has-selected"
                         role="error"
                         test="oscal:selected">A FedRAMP OSCAL SSP information-type confidentiality-, integrity-, or availability-impact must have a
                         selected element.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:base | oscal:selected">
+        <sch:rule context="oscal:base | oscal:selected"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3">
             <sch:let name="fips-199-levels"
                      value="$fedramp-values//fedramp:value-set[@name = 'security-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="cia-impact-has-approved-fips-categorization-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.3"
                         id="cia-impact-has-approved-fips-categorization"
                         role="error"
                         test=". = $fips-199-levels">A FedRAMP OSCAL SSP information-type confidentiality-, integrity-, or availability-impact base or
                         select element must have an approved value.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="sp800-63"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 13">
+    <sch:pattern doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                 doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
+                 id="sp800-63"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5">
         <sch:title>Digital Identity Determination</sch:title>
-        <sch:rule context="oscal:system-characteristics">
+        <sch:rule context="oscal:system-characteristics"
+                  doc:checklist-reference="Section C Check 7"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5">
             <sch:assert diagnostics="has-security-eauth-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-security-eauth-level"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'security-eauth' and @name = 'security-eauth-level']">
                         [Section B Check 3.3] A FedRAMP OSCAL SSP must have a Digital Identity Determination property.</sch:assert>
             <sch:assert diagnostics="has-identity-assurance-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-identity-assurance-level"
                         role="information"
                         test="oscal:prop[@name = 'identity-assurance-level']">[Section B Check 3.3] A FedRAMP OSCAL SSP may have a Digital Identity
                         Determination identity-assurance-level property.</sch:assert>
             <sch:assert diagnostics="has-authenticator-assurance-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-authenticator-assurance-level"
                         role="information"
                         test="oscal:prop[@name = 'authenticator-assurance-level']">[Section B Check 3.3] A FedRAMP OSCAL SSP may have a Digital
                         Identity Determination authenticator-assurance-level property.</sch:assert>
             <sch:assert diagnostics="has-federation-assurance-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-federation-assurance-level"
                         role="information"
                         test="oscal:prop[@name = 'federation-assurance-level']">[Section B Check 3.3] A FedRAMP OSCAL SSP may have a Digital Identity
                         Determination federation-assurance-level property.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @class = 'security-eauth' and @name = 'security-eauth-level']"
+                  doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                   role="error">
-            <!-- FIXME -->
-            <sch:let name="security-eauth-levels"
-                     value="('1', '2', '3')" />
+            <sch:let name="eauth-levels"
+                     value="$fedramp-values//fedramp:value-set[@name = 'eauth-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-security-eauth-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-allowed-security-eauth-level"
                         role="error"
-                        test="@value = $security-eauth-levels">[Section B Check 3.3] A FedRAMP OSCAL SSP must have a Digital Identity Determination
-                        property with an allowed value.</sch:assert>
+                        test="@value = $eauth-levels">[Section B Check 3.3] A FedRAMP OSCAL SSP must have a Digital Identity Determination property
+                        with an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'identity-assurance-level']">
-            <!--<sch:let
-            name="identity-assurance-levels"
-            value="('IAL1', 'IAL2', 'IAL3')" />-->
-            <!-- FIXME -->
+        <sch:rule context="oscal:prop[@name = 'identity-assurance-level']"
+                  doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5">
             <sch:let name="identity-assurance-levels"
-                     value="('1', '2', '3')" />
+                     value="$fedramp-values//fedramp:value-set[@name = 'identity-assurance-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-identity-assurance-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-allowed-identity-assurance-level"
                         role="error"
                         test="@value = $identity-assurance-levels">[Section B Check 3.3] A FedRAMP OSCAL SSP should have an allowed Digital Identity
                         Determination identity-assurance-level property.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'authenticator-assurance-level']">
-            <!--<sch:let
-            name="authenticator-assurance-levels"
-            value="('AAL1', 'AAL2', 'AAL3')" />-->
-            <!-- FIXME -->
+        <sch:rule context="oscal:prop[@name = 'authenticator-assurance-level']"
+                  doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5">
             <sch:let name="authenticator-assurance-levels"
-                     value="('1', '2', '3')" />
+                     value="$fedramp-values//fedramp:value-set[@name = 'authenticator-assurance-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-authenticator-assurance-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-allowed-authenticator-assurance-level"
                         role="error"
                         test="@value = $authenticator-assurance-levels">[Section B Check 3.3] A FedRAMP OSCAL SSP should have an allowed Digital
                         Identity Determination authenticator-assurance-level property.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'federation-assurance-level']">
-            <!--<sch:let
-            name="federation-assurance-levels"
-            value="('FAL1', 'FAL2', 'FAL3')" />-->
-            <!-- FIXME -->
+        <sch:rule context="oscal:prop[@name = 'federation-assurance-level']"
+                  doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5">
             <sch:let name="federation-assurance-levels"
-                     value="('1', '2', '3')" />
+                     value="$fedramp-values//fedramp:value-set[@name = 'federation-assurance-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-federation-assurance-level-diagnostic"
+                        doc:checklist-reference="Section B Check 3.3, Section C Check 7"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.5"
                         id="has-allowed-federation-assurance-level"
                         role="error"
                         test="@value = $federation-assurance-levels">[Section B Check 3.3] A FedRAMP OSCAL SSP should have an allowed Digital
                         Identity Determination federation-assurance-level property.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="system-inventory"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans pp54-61">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
+                 id="system-inventory"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
         <sch:title>FedRAMP OSCAL System Inventory</sch:title>
         <sch:title>A FedRAMP OSCAL SSP must specify system inventory items</sch:title>
-        <sch:rule context="/oscal:system-security-plan/oscal:system-implementation">
+        <sch:rule context="/oscal:system-security-plan/oscal:system-implementation"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <!-- FIXME: determine if essential inventory items are present -->
             <doc:rule>A FedRAMP OSCAL SSP must incorporate inventory-item elements</doc:rule>
             <sch:assert diagnostics="has-inventory-items-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-inventory-items"
                         role="error"
                         test="oscal:inventory-item">A FedRAMP OSCAL SSP must incorporate inventory-item elements.</sch:assert>
         </sch:rule>
         <sch:title>FedRAMP SSP property constraints</sch:title>
-        <sch:rule context="oscal:prop[@name = 'asset-id']">
+        <sch:rule context="oscal:prop[@name = 'asset-id']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:assert diagnostics="has-unique-asset-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-unique-asset-id"
                         role="error"
                         test="count(//oscal:prop[@name = 'asset-id'][@value = current()/@value]) = 1">An asset-id must be unique.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'asset-type']">
+        <sch:rule context="oscal:prop[@name = 'asset-type']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="asset-types"
                      value="$fedramp-values//fedramp:value-set[@name = 'asset-type']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-asset-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-allowed-asset-type"
                         role="warning"
                         test="@value = $asset-types">An asset-type property must have an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'virtual']">
+        <sch:rule context="oscal:prop[@name = 'virtual']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="virtuals"
                      value="$fedramp-values//fedramp:value-set[@name = 'virtual']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-virtual-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-allowed-virtual"
                         role="error"
                         test="@value = $virtuals">A virtual property must have an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'public']">
+        <sch:rule context="oscal:prop[@name = 'public']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="publics"
                      value="$fedramp-values//fedramp:value-set[@name = 'public']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-public-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-allowed-public"
                         role="error"
                         test="@value = $publics">A public property must have an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'allows-authenticated-scan']">
+        <sch:rule context="oscal:prop[@name = 'allows-authenticated-scan']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="allows-authenticated-scans"
                      value="$fedramp-values//fedramp:value-set[@name = 'allows-authenticated-scan']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-allows-authenticated-scan-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-allowed-allows-authenticated-scan"
                         role="error"
                         test="@value = $allows-authenticated-scans">An allows-authenticated-scan property has an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@name = 'is-scanned']">
+        <sch:rule context="oscal:prop[@name = 'is-scanned']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="is-scanneds"
                      value="$fedramp-values//fedramp:value-set[@name = 'is-scanned']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-is-scanned-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-allowed-is-scanned"
                         role="error"
                         test="@value = $is-scanneds">is-scanned property must have an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'scan-type']">
+        <sch:rule context="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'scan-type']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="scan-types"
                      value="$fedramp-values//fedramp:value-set[@name = 'scan-type']//fedramp:enum/@value" />
             <sch:assert diagnostics="has-allowed-scan-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-allowed-scan-type"
                         role="error"
                         test="@value = $scan-types">A scan-type property must have an allowed value.</sch:assert>
         </sch:rule>
         <sch:title>FedRAMP OSCAL SSP inventory components</sch:title>
-        <sch:rule context="oscal:component">
+        <sch:rule context="oscal:component"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:let name="component-types"
                      value="$fedramp-values//fedramp:value-set[@name = 'component-type']//fedramp:enum/@value" />
             <sch:assert diagnostics="component-has-allowed-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="component-has-allowed-type"
                         role="error"
                         test="@type = $component-types">A component must have an allowed type.</sch:assert>
             <sch:assert diagnostics="component-has-asset-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="component-has-asset-type"
                         role="error"
                         test="
                     (: not(@uuid = //oscal:inventory-item/oscal:implemented-component/@component-uuid) or :)
                     oscal:prop[@name = 'asset-type']">A component must have an asset type.</sch:assert>
             <sch:assert diagnostics="component-has-one-asset-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="component-has-one-asset-type"
                         role="error"
                         test="not(oscal:prop[@name = 'asset-type'][2])">A component must have only one asset type.</sch:assert>
         </sch:rule>
         <sch:title>FedRAMP OSCAL SSP inventory items</sch:title>
         <sch:rule context="oscal:inventory-item"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans pp54-61">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5">
             <sch:assert diagnostics="inventory-item-has-uuid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-uuid"
                         role="error"
                         test="@uuid">An inventory-item has a uuid.</sch:assert>
             <sch:assert diagnostics="has-asset-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-asset-id"
                         role="error"
                         test="oscal:prop[@name = 'asset-id']">An inventory-item must have an asset-id.</sch:assert>
             <sch:assert diagnostics="has-one-asset-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="has-one-asset-id"
                         role="error"
                         test="not(oscal:prop[@name = 'asset-id'][2])">An inventory-item must have only one asset-id.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-asset-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-asset-type"
                         role="error"
                         test="oscal:prop[@name = 'asset-type']">An inventory-item must have an asset-type.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-asset-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-asset-type"
                         role="error"
                         test="not(oscal:prop[@name = 'asset-type'][2])">An inventory-item must have only one asset-type.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-virtual-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-virtual"
                         role="error"
                         test="oscal:prop[@name = 'virtual']">An inventory-item must have a virtual property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-virtual-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-virtual"
                         role="error"
                         test="not(oscal:prop[@name = 'virtual'][2])">An inventory-item must have only one virtual property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-public-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-public"
                         role="error"
                         test="oscal:prop[@name = 'public']">An inventory-item must have a public property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-public-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-public"
                         role="error"
                         test="not(oscal:prop[@name = 'public'][2])">An inventory-item must have only one public property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-scan-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-scan-type"
                         role="error"
                         test="oscal:prop[@name = 'scan-type']">An inventory-item must have a scan-type property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-scan-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-scan-type"
                         role="error"
                         test="not(oscal:prop[@name = 'scan-type'][2])">An inventory-item has only one scan-type property.</sch:assert>
@@ -1204,54 +1415,64 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             <sch:let name="is-infrastructure"
                      value="exists(oscal:prop[@name = 'asset-type' and @value = ('os', 'infrastructure')])" />
             <sch:assert diagnostics="inventory-item-has-allows-authenticated-scan-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-allows-authenticated-scan"
                         role="error"
                         test="not($is-infrastructure) or oscal:prop[@name = 'allows-authenticated-scan']">"infrastructure" inventory-item has
                         allows-authenticated-scan.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-allows-authenticated-scan-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-allows-authenticated-scan"
                         role="error"
                         test="not($is-infrastructure) or not(oscal:prop[@name = 'allows-authenticated-scan'][2])">An inventory-item has
                         one-allows-authenticated-scan property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-baseline-configuration-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-baseline-configuration-name"
                         role="error"
                         test="not($is-infrastructure) or oscal:prop[@name = 'baseline-configuration-name']">"infrastructure" inventory-item has
                         baseline-configuration-name.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-baseline-configuration-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-baseline-configuration-name"
                         role="error"
                         test="not($is-infrastructure) or not(oscal:prop[@name = 'baseline-configuration-name'][2])">"infrastructure" inventory-item
                         has only one baseline-configuration-name.</sch:assert>
             <!-- FIXME: Documentation says vendor name is in FedRAMP @ns -->
             <sch:assert diagnostics="inventory-item-has-vendor-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-vendor-name"
                         role="error"
                         test="not($is-infrastructure) or oscal:prop[(: @ns = 'https://fedramp.gov/ns/oscal' and :)@name = 'vendor-name']">
                         "infrastructure" inventory-item has a vendor-name property.</sch:assert>
             <!-- FIXME: Documentation says vendor name is in FedRAMP @ns -->
             <sch:assert diagnostics="inventory-item-has-one-vendor-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-vendor-name"
                         role="error"
                         test="not($is-infrastructure) or not(oscal:prop[(: @ns = 'https://fedramp.gov/ns/oscal' and :)@name = 'vendor-name'][2])">
                         "infrastructure" inventory-item must have only one vendor-name property.</sch:assert>
             <!-- FIXME: perversely, hardware-model is not in FedRAMP @ns -->
             <sch:assert diagnostics="inventory-item-has-hardware-model-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-hardware-model"
                         role="error"
                         test="not($is-infrastructure) or oscal:prop[(: @ns = 'https://fedramp.gov/ns/oscal' and :)@name = 'hardware-model']">
                         "infrastructure" inventory-item must have a hardware-model property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-hardware-model-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-hardware-model"
                         role="error"
                         test="not($is-infrastructure) or not(oscal:prop[(: @ns = 'https://fedramp.gov/ns/oscal' and :)@name = 'hardware-model'][2])">
                         "infrastructure" inventory-item must have only one hardware-model property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-is-scanned-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-is-scanned"
                         role="error"
                         test="not($is-infrastructure) or oscal:prop[@name = 'is-scanned']">"infrastructure" inventory-item must have is-scanned
                         property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-is-scanned-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-is-scanned"
                         role="error"
                         test="not($is-infrastructure) or not(oscal:prop[@name = 'is-scanned'][2])">"infrastructure" inventory-item must have only one
@@ -1261,33 +1482,39 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             <sch:let name="is-software-and-database"
                      value="exists(oscal:prop[@name = 'asset-type' and @value = ('software', 'database')])" />
             <sch:assert diagnostics="inventory-item-has-software-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-software-name"
                         role="error"
                         test="not($is-software-and-database) or oscal:prop[@name = 'software-name']">"software or database" inventory-item must have
                         a software-name property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-software-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-software-name"
                         role="error"
                         test="not($is-software-and-database) or not(oscal:prop[@name = 'software-name'][2])">"software or database" inventory-item
                         must have a software-name property.</sch:assert>
             <!-- FIXME: vague asset categories -->
             <sch:assert diagnostics="inventory-item-has-software-version-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-software-version"
                         role="error"
                         test="not($is-software-and-database) or oscal:prop[@name = 'software-version']">"software or database" inventory-item must
                         have a software-version property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-software-version-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-software-version"
                         role="error"
                         test="not($is-software-and-database) or not(oscal:prop[@name = 'software-version'][2])">"software or database" inventory-item
                         must have one software-version property.</sch:assert>
             <!-- FIXME: vague asset categories -->
             <sch:assert diagnostics="inventory-item-has-function-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-function"
                         role="error"
                         test="not($is-software-and-database) or oscal:prop[@name = 'function']">"software or database" inventory-item must have a
                         function property.</sch:assert>
             <sch:assert diagnostics="inventory-item-has-one-function-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §6.5"
                         id="inventory-item-has-one-function"
                         role="error"
                         test="not($is-software-and-database) or not(oscal:prop[@name = 'function'][2])">"software or database" inventory-item must
@@ -1296,109 +1523,138 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
     </sch:pattern>
     <sch:pattern id="basic-system-characteristics">
         <sch:rule context="oscal:system-implementation"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 43">
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.4.6"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.4.6">
             <sch:assert diagnostics="has-this-system-component-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.4.6"
                         id="has-this-system-component"
                         role="error"
                         test="exists(oscal:component[@type = 'this-system'])">A FedRAMP OSCAL SSP must have a "this-system" component.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:system-characteristics"
-                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 9">
+        <sch:rule context="oscal:system-characteristics">
             <sch:assert diagnostics="has-system-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.1"
                         id="has-system-id"
                         role="error"
+                        see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.1"
                         test="oscal:system-id[@identifier-type = 'https://fedramp.gov']">A FedRAMP OSCAL SSP must have a FedRAMP
                         system-id.</sch:assert>
             <sch:assert diagnostics="has-system-name-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.1"
                         id="has-system-name"
                         role="error"
+                        see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.1"
                         test="oscal:system-name">A FedRAMP OSCAL SSP must have a system-name.</sch:assert>
             <sch:assert diagnostics="has-system-name-short-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.1"
                         id="has-system-name-short"
                         role="error"
+                        see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.1"
                         test="oscal:system-name-short">A FedRAMP OSCAL SSP must have a system-name-short.</sch:assert>
             <sch:assert diagnostics="has-fedramp-authorization-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.2"
                         id="has-fedramp-authorization-type"
                         role="error"
-                        see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 10"
+                        see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.2"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal' and @name = 'authorization-type' and @value = ('fedramp-jab', 'fedramp-agency', 'fedramp-li-saas')]">
             A FedRAMP OSCAL SSP must have a FedRAMP authorization type.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="general-roles"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans pp14-19">
+    <sch:pattern id="general-roles">
         <sch:title>Roles, Locations, Parties, Responsibilities</sch:title>
-        <sch:rule context="oscal:metadata">
+        <sch:rule context="oscal:metadata"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10"
+                  see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10">
             <sch:assert diagnostics="role-defined-system-owner-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6"
                         id="role-defined-system-owner"
                         role="error"
                         test="oscal:role[@id = 'system-owner']">The system-owner role must be defined.</sch:assert>
             <sch:assert diagnostics="role-defined-authorizing-official-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.7"
                         id="role-defined-authorizing-official"
                         role="error"
                         test="oscal:role[@id = 'authorizing-official']">The authorizing-official role must be defined.</sch:assert>
             <sch:assert diagnostics="role-defined-system-poc-management-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.8"
                         id="role-defined-system-poc-management"
                         role="error"
                         test="oscal:role[@id = 'system-poc-management']">The system-poc-management role must be defined.</sch:assert>
             <sch:assert diagnostics="role-defined-system-poc-technical-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.9"
                         id="role-defined-system-poc-technical"
                         role="error"
                         test="oscal:role[@id = 'system-poc-technical']">The system-poc-technical role must be defined.</sch:assert>
             <sch:assert diagnostics="role-defined-system-poc-other-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.9"
                         id="role-defined-system-poc-other"
                         role="error"
                         test="oscal:role[@id = 'system-poc-other']">The system-poc-other role must be defined.</sch:assert>
             <sch:assert diagnostics="role-defined-information-system-security-officer-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.10"
                         id="role-defined-information-system-security-officer"
                         role="error"
                         test="oscal:role[@id = 'information-system-security-officer']">The information-system-security-officer role must be
                         defined.</sch:assert>
             <sch:assert diagnostics="role-defined-authorizing-official-poc-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.11"
                         id="role-defined-authorizing-official-poc"
                         role="error"
                         test="oscal:role[@id = 'authorizing-official-poc']">The authorizing-official-poc role must be defined.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:role">
+        <sch:rule context="oscal:role"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10">
             <sch:assert diagnostics="role-has-title-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10"
                         id="role-has-title"
                         role="error"
                         test="oscal:title">A role must have a title.</sch:assert>
             <sch:assert diagnostics="role-has-responsible-party-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10"
                         id="role-has-responsible-party"
                         role="error"
                         test="//oscal:responsible-party[@role-id = current()/@id]">One or more responsible parties must be defined for each
                         role.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:responsible-party">
+        <sch:rule context="oscal:responsible-party"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10">
             <sch:assert diagnostics="responsible-party-has-person-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10"
                         id="responsible-party-has-person"
                         role="error"
                         test="//oscal:party[@uuid = current()/oscal:party-uuid and @type = 'person']">Each responsible-party party-uuid must identify
                         a person.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:party[@type = 'person']">
+        <sch:rule context="oscal:party[@type = 'person']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10">
             <sch:assert diagnostics="party-has-responsibility-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.6-§4.10"
                         id="party-has-responsibility"
                         role="warning"
                         test="//oscal:responsible-party[oscal:party-uuid = current()/@uuid]">Each person should have a responsibility.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="implementation-roles"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans page 36">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2"
+                 id="implementation-roles"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2">
         <sch:title>Roles related to implemented requirements</sch:title>
-        <sch:rule context="oscal:implemented-requirement">
+        <sch:rule context="oscal:implemented-requirement"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2">
             <sch:assert diagnostics="implemented-requirement-has-responsible-role-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2"
                         id="implemented-requirement-has-responsible-role"
                         role="error"
                         test="oscal:responsible-role">Each implemented-requirement must have one or more responsible-role definitions.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:responsible-role">
+        <sch:rule context="oscal:responsible-role"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2">
             <sch:assert diagnostics="responsible-role-has-role-definition-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2"
                         id="responsible-role-has-role-definition"
                         role="error"
                         test="//oscal:role/@id = current()/@role-id">Each responsible-role must reference a role definition.</sch:assert>
             <sch:assert diagnostics="responsible-role-has-user-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.2"
                         id="responsible-role-has-user"
                         role="error"
                         test="//oscal:role-id = current()/@role-id">Each responsible-role must be referenced in a system-implementation user
@@ -1406,241 +1662,306 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
         </sch:rule>
     </sch:pattern>
     <sch:pattern id="user-properties">
-        <sch:rule context="oscal:user">
+        <sch:rule context="oscal:user"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:assert diagnostics="user-has-role-id-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-has-role-id"
                         role="error"
                         test="oscal:role-id">Every user has a role-id.</sch:assert>
             <sch:assert diagnostics="user-has-user-type-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-has-user-type"
                         role="error"
                         test="oscal:prop[@name = 'type']">Every user has a user type property.</sch:assert>
             <sch:assert diagnostics="user-has-privilege-level-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-has-privilege-level"
                         role="error"
                         test="oscal:prop[@name = 'privilege-level']">Every user has a privilege-level property.</sch:assert>
             <sch:assert diagnostics="user-has-sensitivity-level-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-has-sensitivity-level"
                         role="error"
                         test="oscal:prop[@ns = 'https://fedramp.gov/ns/oscal'][@name = 'sensitivity']">Every user has a sensitivity level
                         property.</sch:assert>
             <sch:assert diagnostics="user-has-authorized-privilege-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-has-authorized-privilege"
                         role="error"
                         test="oscal:authorized-privilege">Every user has one or more authorized-privileges.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:user/oscal:role-id">
+        <sch:rule context="oscal:user/oscal:role-id"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:assert diagnostics="role-id-has-role-definition-diagnostic"
-                        doc:comment="had diagnostics"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="role-id-has-role-definition"
                         role="error"
                         test="//oscal:role[@id = current()]">Each role-id must reference a role definition.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:user/oscal:prop[@name = 'type']">
+        <sch:rule context="oscal:user/oscal:prop[@name = 'type']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:let name="user-types"
                      value="$fedramp-values//fedramp:value-set[@name = 'user-type']//fedramp:enum/@value" />
             <sch:assert diagnostics="user-user-type-has-allowed-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-user-type-has-allowed-value"
                         role="error"
                         test="current()/@value = $user-types">User type property has an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:user/oscal:prop[@name = 'privilege-level']">
+        <sch:rule context="oscal:user/oscal:prop[@name = 'privilege-level']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:let name="user-privilege-levels"
                      value="$fedramp-values//fedramp:value-set[@name = 'user-privilege']//fedramp:enum/@value" />
             <sch:assert diagnostics="user-privilege-level-has-allowed-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-privilege-level-has-allowed-value"
                         role="error"
                         test="current()/@value = $user-privilege-levels">User privilege-level property has an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:user/oscal:prop[@ns = 'https://fedramp.gov/ns/oscal'][@name = 'sensitivity']">
+        <sch:rule context="oscal:user/oscal:prop[@ns = 'https://fedramp.gov/ns/oscal'][@name = 'sensitivity']"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:let name="user-sensitivity-levels"
                      value="$fedramp-values//fedramp:value-set[@name = 'user-sensitivity-level']//fedramp:enum/@value" />
             <sch:assert diagnostics="user-sensitivity-level-has-allowed-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="user-sensitivity-level-has-allowed-value"
                         role="error"
                         test="current()/@value = $user-sensitivity-levels">User sensitivity level property has an allowed value.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:user/oscal:authorized-privilege">
+        <sch:rule context="oscal:user/oscal:authorized-privilege"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:assert diagnostics="authorized-privilege-has-title-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="authorized-privilege-has-title"
                         role="error"
                         test="oscal:title">Every authorized-privilege has a title.</sch:assert>
             <sch:assert diagnostics="authorized-privilege-has-function-performed-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="authorized-privilege-has-function-performed"
                         role="error"
                         test="oscal:function-performed">Every authorized-privilege has one or more function-performed.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:authorized-privilege/oscal:title">
+        <sch:rule context="oscal:authorized-privilege/oscal:title"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:assert diagnostics="authorized-privilege-has-non-empty-title-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="authorized-privilege-has-non-empty-title"
                         role="error"
                         test="current() ne ''">Every authorized-privilege title is non-empty.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:authorized-privilege/oscal:function-performed">
+        <sch:rule context="oscal:authorized-privilege/oscal:function-performed"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18">
             <sch:assert diagnostics="authorized-privilege-has-non-empty-function-performed-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.18"
                         id="authorized-privilege-has-non-empty-function-performed"
                         role="error"
                         test="current() ne ''">Every authorized-privilege has a non-empty function-performed.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="authorization-boundary"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram page 25">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
+                 id="authorization-boundary"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram">
         <sch:title>Authorization Boundary Diagram</sch:title>
-        <sch:rule context="oscal:system-characteristics">
+        <sch:rule context="oscal:system-characteristics"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram">
             <sch:assert diagnostics="has-authorization-boundary-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary"
                         role="error"
                         test="oscal:authorization-boundary">A FedRAMP OSCAL SSP includes an authorization-boundary in its
                         system-characteristics.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:authorization-boundary">
+        <sch:rule context="oscal:authorization-boundary"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram">
             <sch:assert diagnostics="has-authorization-boundary-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-description"
                         role="error"
                         test="oscal:description">A FedRAMP OSCAL SSP has an authorization-boundary description.</sch:assert>
             <sch:assert diagnostics="has-authorization-boundary-diagram-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram"
                         role="error"
                         test="oscal:diagram">A FedRAMP OSCAL SSP has at least one authorization-boundary diagram.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:authorization-boundary/oscal:diagram">
+        <sch:rule context="oscal:authorization-boundary/oscal:diagram"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram">
             <sch:assert diagnostics="has-authorization-boundary-diagram-uuid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-uuid"
                         role="error"
                         test="@uuid">Each FedRAMP OSCAL SSP authorization-boundary diagram has a uuid attribute.</sch:assert>
             <sch:assert diagnostics="has-authorization-boundary-diagram-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-description"
                         role="error"
                         test="oscal:description">Each FedRAMP OSCAL SSP authorization-boundary diagram has a description.</sch:assert>
             <sch:assert diagnostics="has-authorization-boundary-diagram-link-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-link"
                         role="error"
                         test="oscal:link">Each FedRAMP OSCAL SSP authorization-boundary diagram has a link.</sch:assert>
             <sch:assert diagnostics="has-authorization-boundary-diagram-caption-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-caption"
                         role="error"
                         test="oscal:caption">Each FedRAMP OSCAL SSP authorization-boundary diagram has a caption.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:authorization-boundary/oscal:diagram/oscal:link">
+        <sch:rule context="oscal:authorization-boundary/oscal:diagram/oscal:link"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram">
             <sch:assert diagnostics="has-authorization-boundary-diagram-link-rel-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-link-rel"
                         role="error"
                         test="@rel">Each FedRAMP OSCAL SSP authorization-boundary diagram has a link rel attribute.</sch:assert>
             <sch:assert diagnostics="has-authorization-boundary-diagram-link-rel-allowed-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-link-rel-allowed-value"
                         role="error"
                         test="@rel = 'diagram'">Each FedRAMP OSCAL SSP authorization-boundary diagram has a link rel attribute with the value
                         "diagram".</sch:assert>
             <sch:assert diagnostics="has-authorization-boundary-diagram-link-href-target-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Authorization Boundary Diagram"
                         id="has-authorization-boundary-diagram-link-href-target"
                         role="error"
                         test="exists(//oscal:resource[@uuid = substring-after(current()/@href, '#')])">A FedRAMP OSCAL SSP authorization-boundary
                         diagram link references a back-matter resource representing the diagram document.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="network-architecture"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Network Architecture Diagram page 30">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
+                 id="network-architecture"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram">
         <sch:title>Network Architecture Diagram</sch:title>
-        <sch:rule context="oscal:system-characteristics">
+        <sch:rule context="oscal:system-characteristics"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram">
             <sch:assert diagnostics="has-network-architecture-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture"
                         role="error"
                         test="oscal:network-architecture">A FedRAMP OSCAL SSP includes a network-architecture in its
                         system-characteristics.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:network-architecture">
+        <sch:rule context="oscal:network-architecture"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram">
             <sch:assert diagnostics="has-network-architecture-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-description"
                         role="error"
                         test="oscal:description">A FedRAMP OSCAL SSP has a network-architecture description.</sch:assert>
             <sch:assert diagnostics="has-network-architecture-diagram-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram"
                         role="error"
                         test="oscal:diagram">A FedRAMP OSCAL SSP has at least one network-architecture diagram.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:network-architecture/oscal:diagram">
+        <sch:rule context="oscal:network-architecture/oscal:diagram"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram">
             <sch:assert diagnostics="has-network-architecture-diagram-uuid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-uuid"
                         role="error"
                         test="@uuid">Each FedRAMP OSCAL SSP network-architecture diagram has a uuid attribute.</sch:assert>
             <sch:assert diagnostics="has-network-architecture-diagram-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-description"
                         role="error"
                         test="oscal:description">Each FedRAMP OSCAL SSP network-architecture diagram has a description.</sch:assert>
             <sch:assert diagnostics="has-network-architecture-diagram-link-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-link"
                         role="error"
                         test="oscal:link">Each FedRAMP OSCAL SSP network-architecture diagram has a link.</sch:assert>
             <sch:assert diagnostics="has-network-architecture-diagram-caption-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-caption"
                         role="error"
                         test="oscal:caption">Each FedRAMP OSCAL SSP network-architecture diagram has a caption.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:network-architecture/oscal:diagram/oscal:link">
+        <sch:rule context="oscal:network-architecture/oscal:diagram/oscal:link"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram">
             <sch:assert diagnostics="has-network-architecture-diagram-link-rel-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-link-rel"
                         role="error"
                         test="@rel">Each FedRAMP OSCAL SSP network-architecture diagram has a link rel attribute.</sch:assert>
             <sch:assert diagnostics="has-network-architecture-diagram-link-rel-allowed-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-link-rel-allowed-value"
                         role="error"
                         test="@rel = 'diagram'">Each FedRAMP OSCAL SSP network-architecture diagram has a link rel attribute with the value
                         "diagram".</sch:assert>
             <sch:assert diagnostics="has-network-architecture-diagram-link-href-target-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.22 Network Architecture Diagram"
                         id="has-network-architecture-diagram-link-href-target"
                         role="error"
                         test="exists(//oscal:resource[@uuid = substring-after(current()/@href, '#')])">A FedRAMP OSCAL SSP network-architecture
                         diagram link references a back-matter resource representing the diagram document.</sch:assert>
         </sch:rule>
     </sch:pattern>
-    <sch:pattern id="data-flow"
-                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.17 Data Flow Diagram page 32">
+    <sch:pattern doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
+                 id="data-flow"
+                 see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram">
         <sch:title>Data Flow Diagram</sch:title>
-        <sch:rule context="oscal:system-characteristics">
+        <sch:rule context="oscal:system-characteristics"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram">
             <sch:assert diagnostics="has-data-flow-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow"
                         role="error"
                         test="oscal:data-flow">A FedRAMP OSCAL SSP includes a data-flow in its system-characteristics.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:data-flow">
+        <sch:rule context="oscal:data-flow"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram">
             <sch:assert diagnostics="has-data-flow-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-description"
                         role="error"
                         test="oscal:description">A FedRAMP OSCAL SSP has a data-flow description.</sch:assert>
             <sch:assert diagnostics="has-data-flow-diagram-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram"
                         role="error"
                         test="oscal:diagram">A FedRAMP OSCAL SSP has at least one data-flow diagram.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:data-flow/oscal:diagram">
+        <sch:rule context="oscal:data-flow/oscal:diagram"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram">
             <sch:assert diagnostics="has-data-flow-diagram-uuid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-uuid"
                         role="error"
                         test="@uuid">Each FedRAMP OSCAL SSP data-flow diagram has a uuid attribute.</sch:assert>
             <sch:assert diagnostics="has-data-flow-diagram-description-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-description"
                         role="error"
                         test="oscal:description">Each FedRAMP OSCAL SSP data-flow diagram has a description.</sch:assert>
             <sch:assert diagnostics="has-data-flow-diagram-link-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-link"
                         role="error"
                         test="oscal:link">Each FedRAMP OSCAL SSP data-flow diagram has a link.</sch:assert>
             <sch:assert diagnostics="has-data-flow-diagram-caption-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-caption"
                         role="error"
                         test="oscal:caption">Each FedRAMP OSCAL SSP data-flow diagram has a caption.</sch:assert>
         </sch:rule>
-        <sch:rule context="oscal:data-flow/oscal:diagram/oscal:link">
+        <sch:rule context="oscal:data-flow/oscal:diagram/oscal:link"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram">
             <sch:assert diagnostics="has-data-flow-diagram-link-rel-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-link-rel"
                         role="error"
                         test="@rel">Each FedRAMP OSCAL SSP data-flow diagram has a link rel attribute.</sch:assert>
             <sch:assert diagnostics="has-data-flow-diagram-link-rel-allowed-value-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-link-rel-allowed-value"
                         role="error"
                         test="@rel = 'diagram'">Each FedRAMP OSCAL SSP data-flow diagram has a link rel attribute with the value
                         "diagram".</sch:assert>
             <sch:assert diagnostics="has-data-flow-diagram-link-href-target-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §4.24 Data Flow Diagram"
                         id="has-data-flow-diagram-link-href-target"
                         role="error"
                         test="exists(//oscal:resource[@uuid = substring-after(current()/@href, '#')])">A FedRAMP OSCAL SSP data-flow diagram link
@@ -1649,28 +1970,34 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
     </sch:pattern>
     <sch:pattern id="control-implementation">
         <sch:rule context="oscal:system-security-plan"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.1"
                   see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.1">
             <sch:assert diagnostics="system-security-plan-has-import-profile-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.1"
                         id="system-security-plan-has-import-profile"
                         role="error"
                         test="exists(oscal:import-profile)">A FedRAMP OSCAL SSP declares the related FedRAMP OSCAL Profile using an import-profile
                         element.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:import-profile"
+                  doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.1"
                   see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.1">
             <sch:assert diagnostics="import-profile-has-href-attribute-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.1"
                         id="import-profile-has-href-attribute"
                         role="error"
                         test="@href">The import-profile element has an href attribute.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:implemented-requirement">
             <sch:assert diagnostics="implemented-requirement-has-implementation-status-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
                         id="implemented-requirement-has-implementation-status"
                         role="error"
                         see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
                         test="exists(oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name eq 'implementation-status'])">Every
                         implemented-requirement has an implementation-status property.</sch:assert>
             <sch:assert diagnostics="implemented-requirement-has-planned-completion-date-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
                         id="implemented-requirement-has-planned-completion-date"
                         role="error"
                         see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
@@ -1680,6 +2007,7 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
                     else
                         true()">Planned control implementations have a planned completion date.</sch:assert>
             <sch:assert diagnostics="implemented-requirement-has-control-origination-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3.1.1"
                         id="implemented-requirement-has-control-origination"
                         role="error"
                         see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3.1.1"
@@ -1688,12 +2016,14 @@ A FedRAMP SSP must incorporate a procedure document for each of the 17 NIST SP 8
             <sch:let name="control-originations"
                      value="$fedramp-values//fedramp:value-set[@name eq 'control-origination']//fedramp:enum/@value" />
             <sch:assert diagnostics="implemented-requirement-has-allowed-control-origination-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3.1.1"
                         id="implemented-requirement-has-allowed-control-origination"
                         role="error"
                         see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3.1.1"
                         test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name eq 'control-origination' and @value = $control-originations]">
                         Every implemented-requirement has an allowed control-origination property.</sch:assert>
             <sch:assert diagnostics="implemented-requirement-has-leveraged-authorization-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3.1.1"
                         id="implemented-requirement-has-leveraged-authorization"
                         role="error"
                         see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3.1.1"
@@ -1710,12 +2040,14 @@ leveraged-authorization.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name eq 'implementation-status' and @value ne 'implemented']">
             <sch:assert diagnostics="implemented-requirement-has-implementation-status-remarks-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
                         id="implemented-requirement-has-implementation-status-remarks"
                         role="error"
                         test="oscal:remarks">Incomplete control implementations have an explanation.</sch:assert>
         </sch:rule>
         <sch:rule context="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name eq 'planned-completion-date']">
             <sch:assert diagnostics="planned-completion-date-is-valid-diagnostic"
+                        doc:guide-reference="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
                         id="planned-completion-date-is-valid"
                         role="error"
                         see="DRAFT Guide to OSCAL-based FedRAMP System Security Plans §5.3"
@@ -1959,7 +2291,7 @@ leveraged-authorization.</sch:assert>
         <sch:span class="message">lacks procedure attachment resource(s)</sch:span>
         <sch:value-of select="string-join($procedure-hrefs, ', ')" />.</sch:diagnostic>
         <sch:diagnostic doc:assertion="has-reuse"
-                        doc:contect="oscal:by-component/oscal:link[@rel = ('policy', 'procedure')]"
+                        doc:context="oscal:by-component/oscal:link[@rel = ('policy', 'procedure')]"
                         id="has-reuse-diagnostic">A policy or procedure reference was incorrectly re-used.</sch:diagnostic>
         <sch:diagnostic doc:assertion="has-privacy-poc-role"
                         doc:context="oscal:metadata"
@@ -2536,7 +2868,7 @@ leveraged-authorization.</sch:assert>
                         implementation-status.</sch:diagnostic>
         <sch:diagnostic doc:assertion="implemented-requirement-has-implementation-status-remarks"
                         doc:context="oscal:implemented-requirement"
-                        id="implemented-requirement-has-implementation-status-remarks-diagnostic">Thgis incomplete control implementation lacks an
+                        id="implemented-requirement-has-implementation-status-remarks-diagnostic">This incomplete control implementation lacks an
                         explanation.</sch:diagnostic>
         <sch:diagnostic doc:assertion="implemented-requirement-has-planned-completion-date"
                         doc:context="oscal:implemented-requirement"


### PR DESCRIPTION
- Add a reference to the "Guide to OSCAL-based FedRAMP Content" where applicable.
- Add a reference to the "Guide to OSCAL-based FedRAMP System Security Plans" where applicable.
- Add a reference to the "Agency Authorization Review Report" ("checklist") where applicable.
- Change static value constraints to use `fedramp_values.xml` ("Digital Identity" area).
- Correct typo.

Almost all (except one) assertions have references to sections within the "Guide to OSCAL-based FedRAMP System Security Plans". Relevant references to the other documents are less common.