### PR TITLE
avoid empty groups, and ignore Schematron report

### DIFF
--- a/src/validations/rules/assertion-grouping.xsl
+++ b/src/validations/rules/assertion-grouping.xsl
@@ -48,7 +48,7 @@
                                     <xsl:text>FedRAMP Submission Checklist</xsl:text>
                                 </xsl:when>
                                 <xsl:when
-                                    test="current() eq 'guide-reference'">>FedRAMP OSCAL SSP Guide</xsl:when>
+                                    test="current() eq 'guide-reference'">FedRAMP OSCAL SSP Guide</xsl:when>
                                 <xsl:when
                                     test="current() eq 'template-reference'">FedRAMP SSP Template</xsl:when>
                             </xsl:choose>

--- a/src/validations/rules/assertion-grouping.xsl
+++ b/src/validations/rules/assertion-grouping.xsl
@@ -48,7 +48,7 @@
                         <xsl:variable
                             as="xs:string*"
                             name="groupitems"
-                            select="distinct-values($sch//@doc:*[local-name() eq $attribute-local-name])" />
+                            select="distinct-values($sch//@doc:*[local-name() eq $attribute-local-name] ! tokenize(.,',\s*'))" />
                         <!-- create a list of related assertions for each distinct attribute value-->
                         <array
                             key="groups">
@@ -118,8 +118,6 @@
                                         </string>
                                         <array
                                             key="assertionIds">
-                                            <xsl:message
-                                                expand-text="true">{string-join(tokenize($item, ',\s*'),' and ')}</xsl:message>
                                             <xsl:for-each
                                                 select="$sch//assert">
                                                 <xsl:if

--- a/src/validations/rules/assertion-grouping.xsl
+++ b/src/validations/rules/assertion-grouping.xsl
@@ -42,13 +42,22 @@
                     <map>
                         <string
                             key="title">
-                            <xsl:text expand-text="true">FedRAMP {$attribute-local-name}</xsl:text>
+                            <xsl:choose>
+                                <xsl:when
+                                    test="current() eq 'checklist-reference'">
+                                    <xsl:text>FedRAMP Submission Checklist</xsl:text>
+                                </xsl:when>
+                                <xsl:when
+                                    test="current() eq 'guide-reference'">>FedRAMP OSCAL SSP Guide</xsl:when>
+                                <xsl:when
+                                    test="current() eq 'template-reference'">FedRAMP SSP Template</xsl:when>
+                            </xsl:choose>
                         </string>
                         <!-- get the distinct values found in this attribute -->
                         <xsl:variable
                             as="xs:string*"
                             name="groupitems"
-                            select="distinct-values($sch//@doc:*[local-name() eq $attribute-local-name] ! tokenize(.,',\s*'))" />
+                            select="distinct-values($sch//@doc:*[local-name() eq $attribute-local-name] ! tokenize(., ',\s*'))" />
                         <!-- create a list of related assertions for each distinct attribute value-->
                         <array
                             key="groups">


### PR DESCRIPTION
This PR changes the grouping transform (`assertion-grouping.xsl`)

- to avoid empty groups
- to ignore any `<sch:report>`