### PR TITLE
Add rules list document to web bundle

### DIFF
--- a/src/validations/rules/rules.xsl
+++ b/src/validations/rules/rules.xsl
@@ -4,7 +4,7 @@
     version="3.0"
     xmlns:msg="https://fedramp.gov/oscal/fedramp-automation-messages"
     xmlns:doc="https://fedramp.gov/oscal/fedramp-automation-documentation"
-    xmlns:fn="local function"
+    xmlns:fn="local-function"
     xmlns:fv="https://fedramp.gov/ns/oscal"
     xmlns:math="http://www.w3.org/2005/xpath-functions/math"
     xmlns:oscal="http://csrc.nist.gov/ns/oscal/1.0"
@@ -129,7 +129,7 @@
                 </h1>
 
                 <p>
-                    <xsl:text expand-text="true">Last updated { format-dateTime(current-dateTime(), '[MNn] [D] [Y] [H01]:[m01] [ZN,*-3]') }.</xsl:text>
+                    <xsl:text expand-text="true">Last updated { format-dateTime(current-dateTime(), '[MNn] [D] [Y] [H01]:[m01] [Z,*-3]') }.</xsl:text>
                 </p>
 
                 <p>Information from <a

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -16,6 +16,7 @@
     "build:schematron:stage-1": "xslt3 -s:../validations/rules/ssp.sch -xsl:../../vendor/schematron/trunk/schematron/code/iso_dsdl_include.xsl -o:build/ssp-stage1.sch allow-foreign=true diagnose=true",
     "build:schematron:stage-2": "xslt3 -s:build/ssp-stage1.sch -xsl:../../vendor/schematron/trunk/schematron/code/iso_abstract_expand.xsl -o:build/ssp-stage2.sch allow-foreign=true diagnose=true",
     "build:schematron:stage-3": "xslt3 -s:build/ssp-stage2.sch -xsl:../../vendor/schematron/trunk/schematron/code/iso_svrl_for_xslt2.xsl -o:build/ssp.xsl allow-foreign=true diagnose=true",
+    "build:schematron:summary": "xslt3 -s:../validations/rules/rules.xsl -xsl:../validations/rules/rules.xsl -o:public/rules.html",
     "build:snowpack": "snowpack build",
     "cli": "ts-node -r tsconfig-paths/register src/cli/index.ts",
     "clean": "rm -rf build coverage",

--- a/src/web/src/browser/views/components/HomePage.tsx
+++ b/src/web/src/browser/views/components/HomePage.tsx
@@ -99,6 +99,7 @@ const PartiesGrid = () => {
 };
 
 export const HomePage = () => {
+  const { getAssetUrl } = useActions();
   return (
     <div className="usa-prose padding-top-3">
       <h1>Accelerate approvals</h1>
@@ -114,7 +115,8 @@ export const HomePage = () => {
             Open Security Controls Assessment Language (OSCAL)
           </a>{' '}
           validation rules written in{' '}
-          <a href="https://schematron.com/">Schematron</a> format
+          <a href="https://schematron.com/">Schematron</a> format. A{' '}
+          <a href={getAssetUrl('rules.html')}>rules summary</a> is available.
         </li>
         <li>
           This user interface, which will apply validations to a FedRAMP OSCAL


### PR DESCRIPTION
Compiles the `rules.html` summary into the Federalist build, and added a link to the home page: [View here](https://federalist-2372d2fd-fc94-42fe-bcc7-a8af4f664a51.app.cloud.gov/preview/18f/fedramp-automation/rules-list-ui)

Two minor tweaks were necessary to get `rules.xsl` to compile with Saxon-JS.

Home page link:
![image](https://user-images.githubusercontent.com/136512/132058699-9eea8a2c-21d5-4b5c-aedd-54df842ce836.png)

Summary:
![image](https://user-images.githubusercontent.com/136512/132058734-82169c81-1287-48f1-8d3e-f80529090f17.png)
