### PR TITLE
Add JSON to XML SSP conversion

### DIFF
--- a/src/web/package.json
+++ b/src/web/package.json
@@ -10,6 +10,7 @@
     "build:json:cli:assertion-views": "ts-node -r tsconfig-paths/register src/cli/index.ts create-assertion-view",
     "build:json:cli:schematron": "ts-node -r tsconfig-paths/register src/cli/index.ts parse-schematron ../validations/rules/ssp.sch ./public/ssp.json",
     "build:json:sef:assertion-grouping": "xslt3 -xsl:../validations/rules/assertion-grouping.xsl -export:public/assertion-grouping.sef.json -nogo",
+    "build:json:sef:ssp-json-to-xml": "xslt3 -xsl:../../vendor/oscal/xml/convert/oscal_ssp_json-to-xml-converter.xsl -export:public/oscal_ssp_json-to-xml-converter.sef.json -nogo",
     "build:json:sef:ssp.sch": "xslt3 -xsl:build/ssp.xsl -export:public/ssp.sef.json -nogo",
     "build:schematron": "run-s build:schematron:*",
     "build:schematron-java-unused": "cd ../validations && ./bin/validate_with_schematron.sh && cp target/ssp.xsl ../web/public",

--- a/src/web/src/browser/index.ts
+++ b/src/web/src/browser/index.ts
@@ -39,11 +39,11 @@ export const runBrowserContext = ({
 
   const jsonSspToXml = SaxonJsJsonSspToXmlProcessor({
     sefUrl: `${baseUrl}/oscal_ssp_json-to-xml-converter.sef.json`,
-    SaxonJS: SaxonJS,
+    SaxonJS,
   });
   const processSchematron = SaxonJsSchematronProcessorGateway({
     sefUrl: `${baseUrl}/ssp.sef.json`,
-    SaxonJS: SaxonJS,
+    SaxonJS,
     baselinesBaseUrl: `${baseUrl}/baselines`,
     registryBaseUrl: `${baseUrl}/xml`,
   });
@@ -74,7 +74,7 @@ export const runBrowserContext = ({
               // skip indenting the XML for now.
               indentXml: s => Promise.resolve(s),
             },
-            SaxonJS: SaxonJS,
+            SaxonJS,
           }),
           getAssertionViews: async () =>
             fetch(`${baseUrl}/assertion-views.json`).then(response =>

--- a/src/web/src/browser/index.ts
+++ b/src/web/src/browser/index.ts
@@ -15,6 +15,8 @@ import { browserController } from './browser-controller';
 import { createPresenter } from './presenter';
 import { createAppRenderer } from './views';
 
+// The npm version of saxon-js is for node; currently, we load the browser
+// version via a script tag in index.html.
 const SaxonJS = (window as any).SaxonJS;
 
 type BrowserContext = {
@@ -37,14 +39,10 @@ export const runBrowserContext = ({
 
   const jsonSspToXml = SaxonJsJsonSspToXmlProcessor({
     sefUrl: `${baseUrl}/oscal_ssp_json-to-xml-converter.sef.json`,
-    // The npm version of saxon-js is for node; currently, we load the
-    // browser version via a script tag in index.html.
     SaxonJS: SaxonJS,
   });
   const processSchematron = SaxonJsSchematronProcessorGateway({
     sefUrl: `${baseUrl}/ssp.sef.json`,
-    // The npm version of saxon-js is for node; currently, we load the
-    // browser version via a script tag in index.html.
     SaxonJS: SaxonJS,
     baselinesBaseUrl: `${baseUrl}/baselines`,
     registryBaseUrl: `${baseUrl}/xml`,

--- a/src/web/src/shared/adapters/saxon-js-gateway.ts
+++ b/src/web/src/shared/adapters/saxon-js-gateway.ts
@@ -2,6 +2,7 @@ import type { IndentXml } from '@asap/shared/domain/xml';
 import type {
   FailedAssert,
   ParseSchematronAssertions,
+  SchematronJSONToXMLProcessor,
   SchematronProcessor,
   SchematronResult,
   SuccessfulReport,
@@ -367,4 +368,28 @@ export const SaxonJsProcessor =
       console.error(error);
       throw new Error(`Error transforming xml: ${error}`);
     }
+  };
+
+type SaxonJsSaxonJsJsonSspToXmlProcessor = {
+  sefUrl: string;
+  SaxonJS: any;
+};
+
+export const SaxonJsJsonSspToXmlProcessor =
+  (ctx: SaxonJsSaxonJsJsonSspToXmlProcessor): SchematronJSONToXMLProcessor =>
+  (jsonUrl: string) => {
+    return ctx.SaxonJS.transform(
+      {
+        stylesheetLocation: ctx.sefUrl,
+        destination: 'serialized',
+        initialTemplate: 'from-json',
+        sourceText: '<dummy></dummy>',
+        stylesheetParams: {
+          file: jsonUrl,
+        },
+      },
+      'async',
+    ).then((output: any) => {
+      return output.principalResult as string;
+    });
   };

--- a/src/web/src/shared/adapters/saxon-js-gateway.ts
+++ b/src/web/src/shared/adapters/saxon-js-gateway.ts
@@ -377,15 +377,14 @@ type SaxonJsSaxonJsJsonSspToXmlProcessor = {
 
 export const SaxonJsJsonSspToXmlProcessor =
   (ctx: SaxonJsSaxonJsJsonSspToXmlProcessor): SchematronJSONToXMLProcessor =>
-  (jsonUrl: string) => {
+  (jsonString: string) => {
     return ctx.SaxonJS.transform(
       {
         stylesheetLocation: ctx.sefUrl,
         destination: 'serialized',
         initialTemplate: 'from-json',
-        sourceText: '<dummy></dummy>',
         stylesheetParams: {
-          file: jsonUrl,
+          file: 'data:application/json;base64,' + btoa(jsonString),
         },
       },
       'async',

--- a/src/web/src/shared/domain/github.ts
+++ b/src/web/src/shared/domain/github.ts
@@ -12,6 +12,7 @@ export const DEFAULT_REPOSITORY: GithubRepository = {
 
 const SAMPLE_SSP_PATHS = [
   'src/content/templates/ssp/xml/FedRAMP-SSP-OSCAL-Template.xml',
+  'dist/content/templates/ssp/json/FedRAMP-SSP-OSCAL-Template.json',
 ];
 
 export const getBranchTreeUrl = (

--- a/src/web/src/shared/use-cases/schematron.ts
+++ b/src/web/src/shared/use-cases/schematron.ts
@@ -29,6 +29,10 @@ export type ValidationReport = {
   failedAsserts: FailedAssert[];
 };
 
+export type SchematronJSONToXMLProcessor = (
+  jsonString: string,
+) => Promise<string>;
+
 export type SchematronProcessor = (
   oscalXmlString: string,
 ) => Promise<SchematronResult>;

--- a/src/web/src/shared/use-cases/validate-ssp-xml.test.ts
+++ b/src/web/src/shared/use-cases/validate-ssp-xml.test.ts
@@ -33,6 +33,7 @@ describe('validate ssp url use case', () => {
           }),
         });
       }),
+      jsonSspToXml: jest.fn().mockReturnValue(xmlText),
       processSchematron: jest.fn().mockImplementation(xmlStr => {
         expect(xmlStr).toEqual(xmlText);
         return MOCK_SCHEMATRON_RESULT;

--- a/src/web/src/shared/use-cases/validate-ssp-xml.ts
+++ b/src/web/src/shared/use-cases/validate-ssp-xml.ts
@@ -1,4 +1,5 @@
 import type {
+  SchematronJSONToXMLProcessor,
   SchematronProcessor,
   SchematronResult,
   ValidationReport,
@@ -15,6 +16,7 @@ export const ValidateSSPUseCase =
 export type ValidateSSPUseCase = ReturnType<typeof ValidateSSPUseCase>;
 
 type ValidateSSPUrlUseCaseContext = {
+  jsonSspToXml: SchematronJSONToXMLProcessor;
   processSchematron: SchematronProcessor;
   fetch: typeof fetch;
 };
@@ -32,11 +34,19 @@ const generateSchematronReport = (
 };
 
 export const ValidateSSPUrlUseCase =
-  (ctx: ValidateSSPUrlUseCaseContext) => (xmlUrl: string) => {
+  (ctx: ValidateSSPUrlUseCaseContext) => (fileUrl: string) => {
     let xmlText: string;
-    return ctx
-      .fetch(xmlUrl)
-      .then(response => response.text())
+    return (() => {
+      if (fileUrl.endsWith('.json')) {
+        return ctx.jsonSspToXml(fileUrl);
+      } else {
+        return ctx.fetch(fileUrl).then(response => response.text());
+      }
+    })()
+      .then(text => {
+        xmlText = text;
+        return xmlText;
+      })
       .then(text => {
         xmlText = text;
         return xmlText;

--- a/src/web/src/shared/use-cases/validate-ssp-xml.ts
+++ b/src/web/src/shared/use-cases/validate-ssp-xml.ts
@@ -36,13 +36,18 @@ const generateSchematronReport = (
 export const ValidateSSPUrlUseCase =
   (ctx: ValidateSSPUrlUseCaseContext) => (fileUrl: string) => {
     let xmlText: string;
-    return (() => {
-      if (fileUrl.endsWith('.json')) {
-        return ctx.jsonSspToXml(fileUrl);
-      } else {
-        return ctx.fetch(fileUrl).then(response => response.text());
-      }
-    })()
+
+    return ctx
+      .fetch(fileUrl)
+      .then(response => response.text())
+      .then(text => {
+        // Convert JSON to XML, if necessary.
+        if (fileUrl.endsWith('.json')) {
+          return ctx.jsonSspToXml(text);
+        } else {
+          return text;
+        }
+      })
       .then(text => {
         xmlText = text;
         return xmlText;


### PR DESCRIPTION
Just to determine if the current OSCAL SSP JSON to XML converter works with SaxonJS - this adds the sample JSON document to the presets, and converts to XML. Only works with remote URLs, due to the way the OSCAL transform is implemented.