### PR TITLE
Add assertion for adequate inherited description.

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -3075,6 +3075,20 @@
                 test="not(@value castable as xs:date) or (@value castable as xs:date and xs:date(@value) gt current-date())">Planned completion date
                 is not past.</sch:assert>
         </sch:rule>
+
+        <sch:rule
+            context="oscal:inherited/oscal:description">
+
+            <sch:assert
+                diagnostics="has-inherited-description-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5.4.9"
+                id="has-inherited-description"
+                role="error"
+                test="count(tokenize(normalize-space(.), '\s+')) ge 32">An inherited control implementation description must contain at least 32
+                words.</sch:assert>
+
+        </sch:rule>
+        
     </sch:pattern>
     <sch:pattern
         doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.13-14"
@@ -4533,6 +4547,10 @@
             doc:assertion="planned-completion-date-is-not-past"
             doc:context="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name eq 'planned-completion-date']"
             id="planned-completion-date-is-not-past-diagnostic">This planned completion date references a past time.</sch:diagnostic>
+        <sch:diagnostic
+            doc:assertion="has-inherited-description"
+            doc:context="oscal:inherited/oscal:description"
+            id="has-inherited-description-diagnostic">This inherited control implementation description has less than 32 words.</sch:diagnostic>
         <sch:diagnostic
             doc:assertion="has-cloud-service-model"
             doc:context="oscal:system-characteristics"

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -6559,7 +6559,7 @@
                         </system-implementation>
                     </system-security-plan>
                 </x:context>
-                
+
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of current internal users.">
                     <x:scenario
@@ -6569,7 +6569,7 @@
                             label="that is correct" />
                     </x:scenario>
                 </x:scenario>
-                
+
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of current external users.">
                     <x:scenario
@@ -6579,7 +6579,7 @@
                             label="that is correct" />
                     </x:scenario>
                 </x:scenario>
-                
+
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of future internal users.">
                     <x:scenario
@@ -9111,6 +9111,40 @@
                     label="that is an error" />
             </x:scenario>
         </x:scenario>
+
+        <x:scenario
+            label="Inherited description is sufficient.">
+            <x:scenario
+                label="When that is true">
+                <x:context>
+                    <inherited
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                        <description>
+                            <p>word word word word word word word word word word word word word word word word word word word word word word word word
+                                word word word word word word word word.</p>
+                        </description>
+                    </inherited>
+                </x:context>
+                <x:expect-not-assert
+                    id="has-inherited-description"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="When that is false">
+                <x:context>
+                    <inherited
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                        <description>
+                            <p>word word word word word word.</p>
+                        </description>
+                    </inherited>
+                </x:context>
+                <x:expect-assert
+                    id="has-inherited-description"
+                    label="that is an error" />
+            </x:scenario>
+        </x:scenario>
+
     </x:scenario>
     <x:scenario
         label="FedRAMP OSCAL SSP Cloud Service and Deployment Models">


### PR DESCRIPTION
This PR adds an assertion for `inherited/description` which requires it contain at least 32 words.

Closes #248.