### PR TITLE
Add missing role attributes

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -1393,6 +1393,7 @@
                 diagnostics="has-accessible-CMVP-validation-details-diagnostic"
                 doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans Appendix A"
                 id="has-accessible-CMVP-validation-details"
+                role="error"
                 test="not($use-remote-resources) or unparsed-text-available(@href)">The NIST Cryptographic Module Validation Program (CMVP)
                 certificate detail page is available.</sch:assert>
             <sch:assert
@@ -1644,8 +1645,8 @@
                     if (oscal:base ne oscal:selected) then
                         exists(oscal:adjustment-justification)
                     else
-                        true()">When SP 800-60 base and selected impacts levels differ for a given information type, the SSP must include a justification for the
-                difference.</sch:assert>
+                        true()">When SP 800-60 base and selected impacts levels differ for a given information type, the SSP must
+                include a justification for the difference.</sch:assert>
         </sch:rule>
         <sch:rule
             context="oscal:base | oscal:selected"
@@ -3105,7 +3106,7 @@
                 words.</sch:assert>
 
         </sch:rule>
-        
+
     </sch:pattern>
     <sch:pattern
         doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.13-14"
@@ -3278,6 +3279,7 @@
                 doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.20"
                 doc:template-reference="System Security Plan Template §11"
                 id="interconnection-has-local-and-remote-addresses"
+                role="error"
                 test="
                     (oscal:prop[@name eq 'ipv4-address' and @class eq 'local'] and oscal:prop[@name eq 'ipv4-address' and @class eq 'remote'])
                     or
@@ -3936,8 +3938,8 @@
         <sch:diagnostic
             doc:assertion="cia-impact-has-adjustment-justification"
             doc:context="oscal:confidentiality-impact | oscal:integrity-impact | oscal:availability-impact"
-            id="cia-impact-has-adjustment-justification-diagnostic">These SP 800-60 base and selected impact levels differ, but no
-            justification for the difference is supplied.</sch:diagnostic>
+            id="cia-impact-has-adjustment-justification-diagnostic">These SP 800-60 base and selected impact levels differ, but no justification for
+            the difference is supplied.</sch:diagnostic>
         <sch:diagnostic
             doc:assertion="cia-impact-has-approved-fips-categorization"
             doc:context="oscal:base | oscal:selected"

--- a/src/validations/sch/sch.sch
+++ b/src/validations/sch/sch.sch
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model schematypens="http://purl.oclc.org/dsdl/schematron" href="sch.sch" phase="advanced" title="Schematron Style Guide for FedRAMP Validations" ?>
 <sch:schema
     defaultPhase="basic"
     queryBinding="xslt2"
@@ -100,7 +99,7 @@
             <sch:assert
                 diagnostics="has-role-attribute-diagnostic"
                 id="has-role-attribute"
-                role="warning"
+                role="error"
                 sqf:fix="add-role"
                 test="@role">Every Schematron assertion has a role.</sch:assert>
 
@@ -113,11 +112,20 @@
                     node-type="attribute"
                     target="role" />
             </sqf:fix>
+            
+            <sch:assert test="true()"></sch:assert>
+
+            <sch:assert
+                diagnostics="has-allowed-role-attribute-diagnostic"
+                id="has-allowed-role-attribute"
+                role="error"
+                sqf:fix="add-role"
+                test="@role = ('information', 'warning', 'error', 'fatal')">Every Schematron assertion has an allowed role.</sch:assert>
 
             <sch:assert
                 diagnostics="has-diagnostics-attribute-diagnostic"
                 id="has-diagnostics-attribute"
-                role="warning"
+                role="error"
                 sqf:fix="add-diagnostics-attribute"
                 test="local-name() eq 'report' or @diagnostics">Every Schematron assertion has diagnostics.</sch:assert>
 
@@ -310,12 +318,12 @@
                 id="has-doc-assertion-attribute"
                 role="warning"
                 test="@doc:assertion">Every diagnostic has a doc:assertion attribute.</sch:assert>
-            
+
             <sch:assert
                 id="has-doc-context-attribute"
                 role="warning"
                 test="@doc:context">Every diagnostic has a doc:context attribute.</sch:assert>
-            
+
         </sch:rule>
 
     </sch:pattern>
@@ -337,6 +345,10 @@
             id="has-role-attribute-diagnostic"><sch:value-of
                 select="name()" /> id="<sch:value-of
                 select="@id" />" lacks the role attribute.</sch:diagnostic>
+        <sch:diagnostic
+            id="has-allowed-role-attribute-diagnostic"><sch:value-of
+                select="name()" /> id="<sch:value-of
+                select="@id" />" has an invalid role attribute.</sch:diagnostic>
         <sch:diagnostic
             id="has-diagnostics-attribute-diagnostic"><sch:value-of
                 select="name()" /> id="<sch:value-of


### PR DESCRIPTION
This PR adds missing role attributes to FedRAMP Schematron checks. It also adds a check to the Schematron checks for FedRAMP Schematron (`sch.sch`) to ensure assertion roles are constrained to four values ('information', 'warning', 'error', 'fatal').

This partially addresses #277.