### PR TITLE
 Correct context for user counts

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -2181,6 +2181,36 @@
             context="oscal:system-implementation"
             doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5.4.6"
             see="Guide to OSCAL-based FedRAMP System Security Plans §5.4.6">
+            
+            <sch:assert
+                diagnostics="has-users-internal-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
+                id="has-users-internal"
+                role="error"
+                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-internal' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
+                FedRAMP SSP must specify the number of current internal users.</sch:assert>
+            <sch:assert
+                diagnostics="has-users-external-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
+                id="has-users-external"
+                role="error"
+                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-external' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
+                FedRAMP SSP must specify the number of current external users.</sch:assert>
+            <sch:assert
+                diagnostics="has-users-internal-future-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
+                id="has-users-internal-future"
+                role="error"
+                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-internal-future' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
+                FedRAMP SSP must specify the number of future internal users.</sch:assert>
+            <sch:assert
+                diagnostics="has-users-external-future-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
+                id="has-users-external-future"
+                role="error"
+                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-external-future' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
+                FedRAMP SSP must specify the number of future external users.</sch:assert>
+            
             <sch:assert
                 diagnostics="has-this-system-component-diagnostic"
                 doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5.4.6"
@@ -2233,35 +2263,6 @@
                 see="Guide to OSCAL-based FedRAMP System Security Plans §4.2"
                 test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name eq 'authorization-type' and @value = $authorization-types]">A FedRAMP
                 SSP must have an allowed FedRAMP authorization type.</sch:assert>
-
-            <sch:assert
-                diagnostics="has-users-internal-diagnostic"
-                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
-                id="has-users-internal"
-                role="error"
-                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-internal' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
-                FedRAMP SSP must specify the number of current internal users.</sch:assert>
-            <sch:assert
-                diagnostics="has-users-external-diagnostic"
-                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
-                id="has-users-external"
-                role="error"
-                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-external' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
-                FedRAMP SSP must specify the number of current external users.</sch:assert>
-            <sch:assert
-                diagnostics="has-users-internal-future-diagnostic"
-                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
-                id="has-users-internal-future"
-                role="error"
-                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-internal-future' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
-                FedRAMP SSP must specify the number of future internal users.</sch:assert>
-            <sch:assert
-                diagnostics="has-users-external-future-diagnostic"
-                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §4.19"
-                id="has-users-external-future"
-                role="error"
-                test="oscal:prop[@ns eq 'https://fedramp.gov/ns/oscal' and @name = 'users-external-future' and @value castable as xs:integer and @value cast as xs:integer ge 0]">A
-                FedRAMP SSP must specify the number of future external users.</sch:assert>
 
         </sch:rule>
     </sch:pattern>

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -6516,7 +6516,7 @@
             <x:scenario
                 label="A FedRAMP SSP must specify the number of current internal users.">
                 <x:scenario
-                    label="When it does">
+                    label="When it does not">
                     <x:expect-assert
                         id="has-users-internal"
                         label="that is correct" />
@@ -6526,7 +6526,7 @@
             <x:scenario
                 label="A FedRAMP SSP must specify the number of current external users.">
                 <x:scenario
-                    label="When it does">
+                    label="When it does not">
                     <x:expect-assert
                         id="has-users-external"
                         label="that is correct" />
@@ -6536,7 +6536,7 @@
             <x:scenario
                 label="A FedRAMP SSP must specify the number of future internal users.">
                 <x:scenario
-                    label="When it does">
+                    label="When it does not">
                     <x:expect-assert
                         id="has-users-internal-future"
                         label="that is correct" />
@@ -6546,7 +6546,7 @@
             <x:scenario
                 label="A FedRAMP SSP must specify the number of future external users.">
                 <x:scenario
-                    label="When it does">
+                    label="When it does not">
                     <x:expect-assert
                         id="has-users-external-future"
                         label="that is correct" />

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -6319,6 +6319,16 @@
                             name="authorization-type"
                             ns="https://fedramp.gov/ns/oscal"
                             value="fedramp-agency" />
+                        <system-id
+                            identifier-type="https://fedramp.gov">F00000000</system-id>
+                        <system-name>System's Full Name</system-name>
+                        <system-name-short>System's Short Name or Acronym</system-name-short>
+                        <description>
+                            <p>word word word word word word word word word word word word word word word word word word word word word word word word
+                                word word word word word word word word word.</p>
+                        </description>
+                    </system-characteristics>
+                    <system-implementation>
                         <prop
                             name="users-internal"
                             ns="https://fedramp.gov/ns/oscal"
@@ -6335,16 +6345,6 @@
                             name="users-external-future"
                             ns="https://fedramp.gov/ns/oscal"
                             value="1" />
-                        <system-id
-                            identifier-type="https://fedramp.gov">F00000000</system-id>
-                        <system-name>System's Full Name</system-name>
-                        <system-name-short>System's Short Name or Acronym</system-name-short>
-                        <description>
-                            <p>word word word word word word word word word word word word word word word word word word word word word word word word
-                                word word word word word word word word word.</p>
-                        </description>
-                    </system-characteristics>
-                    <system-implementation>
                         <component
                             type="this-system" />
                     </system-implementation>

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -6563,6 +6563,12 @@
                                 name="authorization-type"
                                 ns="https://fedramp.gov/ns/oscal"
                                 value="fedramp-agency" />
+                            <system-id
+                                identifier-type="https://fedramp.gov">F00000000</system-id>
+                            <system-name>System's Full Name</system-name>
+                            <system-name-short>System's Short Name or Acronym</system-name-short>
+                        </system-characteristics>
+                        <system-implementation>
                             <prop
                                 name="users-internal"
                                 ns="https://fedramp.gov/ns/oscal"
@@ -6579,12 +6585,6 @@
                                 name="users-external-future"
                                 ns="https://fedramp.gov/ns/oscal"
                                 value="-1" />
-                            <system-id
-                                identifier-type="https://fedramp.gov">F00000000</system-id>
-                            <system-name>System's Full Name</system-name>
-                            <system-name-short>System's Short Name or Acronym</system-name-short>
-                        </system-characteristics>
-                        <system-implementation>
                             <component
                                 type="this-system" />
                         </system-implementation>

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -6500,7 +6500,7 @@
                     label="When it is not">
                     <x:expect-assert
                         id="has-system-description"
-                        label="that is correct" />
+                        label="that is an error" />
                 </x:scenario>
             </x:scenario>
             <x:scenario
@@ -6519,7 +6519,7 @@
                     label="When it does not">
                     <x:expect-assert
                         id="has-users-internal"
-                        label="that is correct" />
+                        label="that is an error" />
                 </x:scenario>
             </x:scenario>
 
@@ -6529,7 +6529,7 @@
                     label="When it does not">
                     <x:expect-assert
                         id="has-users-external"
-                        label="that is correct" />
+                        label="that is an error" />
                 </x:scenario>
             </x:scenario>
 
@@ -6539,7 +6539,7 @@
                     label="When it does not">
                     <x:expect-assert
                         id="has-users-internal-future"
-                        label="that is correct" />
+                        label="that is an error" />
                 </x:scenario>
             </x:scenario>
 
@@ -6549,7 +6549,7 @@
                     label="When it does not">
                     <x:expect-assert
                         id="has-users-external-future"
-                        label="that is correct" />
+                        label="that is an error" />
                 </x:scenario>
             </x:scenario>
 
@@ -6594,39 +6594,39 @@
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of current internal users.">
                     <x:scenario
-                        label="When it does">
+                        label="When it does not">
                         <x:expect-assert
                             id="has-users-internal"
-                            label="that is correct" />
+                            label="that is an error" />
                     </x:scenario>
                 </x:scenario>
 
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of current external users.">
                     <x:scenario
-                        label="When it does">
+                        label="When it does not">
                         <x:expect-assert
                             id="has-users-external"
-                            label="that is correct" />
+                            label="that is an error" />
                     </x:scenario>
                 </x:scenario>
 
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of future internal users.">
                     <x:scenario
-                        label="When it does">
+                        label="When it does not">
                         <x:expect-assert
                             id="has-users-internal-future"
-                            label="that is correct" />
+                            label="that is an error" />
                     </x:scenario>
                 </x:scenario>
                 <x:scenario
                     label="A FedRAMP SSP must specify a non-negative number of future external users.">
                     <x:scenario
-                        label="When it does">
+                        label="When it does not">
                         <x:expect-assert
                             id="has-users-external-future"
-                            label="that is correct" />
+                            label="that is an error" />
                     </x:scenario>
                 </x:scenario>
             </x:scenario>


### PR DESCRIPTION
Testing of sample SSP generation indicated that the context for user counts was incorrect. The context should be `system-implementation` rather than `system-characteristics`.

Closes #280.