### PR TITLE
Handle both variants of artifact linking

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -1094,11 +1094,18 @@
                 doc:template-reference="System Security Plan Template §15 Attachment 1"
                 id="has-policy-link"
                 role="error"
-                test="descendant::oscal:by-component/oscal:link[@rel eq 'policy']">[Section B Check 3.1] A FedRAMP SSP must incorporate a policy
-                document for each of the 17 NIST SP 800-54 Revision 4 control families.</sch:assert>
+                test="
+                    (: legacy approach :)
+                    (descendant::oscal:by-component/oscal:link[@rel eq 'policy'])
+                    or
+                    (: component approach :)
+                    (some $c in
+                    //oscal:component[@uuid = current()/descendant::oscal:by-component/@component-uuid]
+                        satisfies $c/@type = 'policy' and $c/oscal:link[@rel eq 'policy'])">[Section B Check 3.1] A FedRAMP SSP must
+                incorporate a policy document for each of the 17 NIST SP 800-54 Revision 4 control families.</sch:assert>
             <sch:let
                 name="policy-hrefs"
-                value="distinct-values(descendant::oscal:by-component/oscal:link[@rel eq 'policy']/@href ! substring-after(., '#'))" />
+                value="distinct-values((descendant::oscal:by-component/oscal:link[@rel eq 'policy']/@href, //oscal:component[@type = 'policy' and @uuid = current()/descendant::oscal:by-component/@component-uuid]/oscal:link/@href) ! substring-after(., '#'))" />
             <sch:assert
                 diagnostics="has-policy-attachment-resource-diagnostic"
                 doc:checklist-reference="Section B Check 3.1"
@@ -1119,11 +1126,18 @@
                 doc:template-reference="System Security Plan Template §15"
                 id="has-procedure-link"
                 role="error"
-                test="descendant::oscal:by-component/oscal:link[@rel eq 'procedure']">[Section B Check 3.1] A FedRAMP SSP must incorporate a procedure
-                document for each of the 17 NIST SP 800-54 Revision 4 control families.</sch:assert>
+                test="
+                    (: legacy approach :)
+                    (descendant::oscal:by-component/oscal:link[@rel eq 'procedure'])
+                    or
+                    (: component approach :)
+                    (some $c in
+                    //oscal:component[@uuid = current()/descendant::oscal:by-component/@component-uuid]
+                        satisfies $c/@type = 'procedure' and $c/oscal:link[@rel eq 'procedure'])">[Section B Check 3.1] A FedRAMP SSP
+                must incorporate a procedure document for each of the 17 NIST SP 800-54 Revision 4 control families.</sch:assert>
             <sch:let
                 name="procedure-hrefs"
-                value="distinct-values(descendant::oscal:by-component/oscal:link[@rel eq 'procedure']/@href ! substring-after(., '#'))" />
+                value="distinct-values((descendant::oscal:by-component/oscal:link[@rel eq 'procedure']/@href, //oscal:component[@type = 'procedure' and @uuid = current()/descendant::oscal:by-component/@component-uuid]/oscal:link/@href) ! substring-after(., '#'))" />
             <sch:assert
                 diagnostics="has-procedure-attachment-resource-diagnostic"
                 doc:checklist-reference="Section B Check 3.1"
@@ -3712,7 +3726,7 @@
             <sch:value-of
                 select="local-name()" />
             <sch:value-of
-                select="@control-id" /> lacks policy reference(s) (via by-component link).</sch:diagnostic>
+                select="@control-id" /> lacks policy reference(s) via legacy or component approach.</sch:diagnostic>
         <sch:diagnostic
             doc:assertion="has-policy-attachment-resource"
             doc:context="oscal:implemented-requirement[matches(@control-id, '^[a-z]{2}-1$')]"
@@ -3729,7 +3743,7 @@
             <sch:value-of
                 select="local-name()" />
             <sch:value-of
-                select="@control-id" /> lacks procedure reference(s) (via by-component link).</sch:diagnostic>
+                select="@control-id" /> lacks procedure reference(s) via legacy or component approach.</sch:diagnostic>
         <sch:diagnostic
             doc:assertion="has-procedure-attachment-resource"
             doc:context="oscal:implemented-requirement[matches(@control-id, '^[a-z]{2}-1$')]"

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -2508,12 +2508,13 @@
                         label="that is an error" />
                 </x:scenario>
             </x:scenario>
+
             <x:scenario
                 label="Policy and Procedure Attachments:">
                 <x:scenario
                     label="for the policy facet of P&amp;P controls, ">
                     <x:scenario
-                        label="when the policy link to the resource declaring the policy document attachment">
+                        label="when the policy link to the resource declaring the policy document attachment is via a direct link and">
                         <x:scenario
                             label="is present">
                             <x:context>
@@ -2577,6 +2578,107 @@
                                 label="that is an error" />
                         </x:scenario>
                     </x:scenario>
+
+                    <x:scenario
+                        label="when the policy link to the resource declaring the policy document attachment is via a component and">
+                        <x:scenario
+                            label="is present">
+                            <x:context>
+                                <system-security-plan
+                                    xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                                    <system-implementation>
+                                        <component
+                                            type="policy"
+                                            uuid="5a16a6df-730c-47b9-99ae-8d732e5ee478">
+                                            <title>SI-1 - Policy document</title>
+                                            <description>
+                                                <p>SI-1 System and Information Integrity Policy and Procedures - Policy</p>
+                                            </description>
+                                            <prop
+                                                name="asset-type"
+                                                value="document" />
+                                            <link
+                                                href="#232e28ae-1c34-4954-8ed7-31e678ec0d77"
+                                                rel="policy" />
+                                            <status
+                                                state="operational" />
+                                        </component>
+                                    </system-implementation>
+                                    <control-implementation>
+                                        <implemented-requirement
+                                            control-id="si-1">
+                                            <by-component
+                                                component-uuid="5a16a6df-730c-47b9-99ae-8d732e5ee478"
+                                                uuid="f7bce955-cdc2-4976-bc27-2ff1023fff24"><description>
+                                                    <p>System and Information Integrity Policy and Procedures: policy component reference</p>
+                                                </description>
+                                            </by-component>
+                                        </implemented-requirement>
+                                    </control-implementation>
+                                    <back-matter>
+                                        <resource
+                                            uuid="232e28ae-1c34-4954-8ed7-31e678ec0d77">
+                                            <prop
+                                                name="type"
+                                                value="policy" />
+                                        </resource>
+                                    </back-matter>
+                                </system-security-plan>
+                            </x:context>
+                            <x:expect-not-assert
+                                id="has-policy-link"
+                                label="that is correct" />
+                        </x:scenario>
+                        <x:scenario
+                            label="is absent">
+                            <x:context>
+                                <system-security-plan
+                                    xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                                    <system-implementation>
+                                        <component
+                                            type="policy"
+                                            uuid="5a16a6df-730c-47b9-99ae-8d732e5ee478">
+                                            <title>SI-1 - Policy document</title>
+                                            <description>
+                                                <p>SI-1 System and Information Integrity Policy and Procedures - Policy</p>
+                                            </description>
+                                            <prop
+                                                name="asset-type"
+                                                value="document" />
+                                            <!--<link
+                                                href="#232e28ae-1c34-4954-8ed7-31e678ec0d77"
+                                                rel="policy" />-->
+                                            <status
+                                                state="operational" />
+                                        </component>
+                                    </system-implementation>
+                                    <control-implementation>
+                                        <implemented-requirement
+                                            control-id="si-1">
+                                            <by-component
+                                                component-uuid="5a16a6df-730c-47b9-99ae-8d732e5ee478"
+                                                uuid="f7bce955-cdc2-4976-bc27-2ff1023fff24"><description>
+                                                    <p>System and Information Integrity Policy and Procedures: policy component reference</p>
+                                                </description>
+                                            </by-component>
+                                        </implemented-requirement>
+                                    </control-implementation>
+                                    <back-matter>
+                                        <resource
+                                            uuid="232e28ae-1c34-4954-8ed7-31e678ec0d77">
+                                            <prop
+                                                name="type"
+                                                value="policy" />
+                                        </resource>
+                                    </back-matter>
+                                </system-security-plan>
+                            </x:context>
+                            <x:expect-assert
+                                id="has-policy-link"
+                                label="that is an error" />
+                        </x:scenario>
+                    </x:scenario>
+
                     <x:scenario
                         label="when the policy attachment resource">
                         <x:scenario
@@ -2643,10 +2745,11 @@
                         </x:scenario>
                     </x:scenario>
                 </x:scenario>
+
                 <x:scenario
                     label="for the procedure facet of P&amp;P controls, ">
                     <x:scenario
-                        label="when the procedure link to the resource declaring the procedure document attachment">
+                        label="when the procedure link to the resource declaring the procedure document attachment is via a direct link and">
                         <x:scenario
                             label="is present">
                             <x:context>
@@ -2710,6 +2813,111 @@
                                 label="that is an error" />
                         </x:scenario>
                     </x:scenario>
+
+                    <x:scenario
+                        label="when the procedure link to the resource declaring the procedure document attachment is via a component and">
+                        <x:scenario
+                            label="is present">
+                            <x:context>
+                                <system-security-plan
+                                    xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                                    <system-implementation>
+                                        <component
+                                            type="procedure"
+                                            uuid="cda2be7f-832f-45a6-9093-d3efbab3ea76">
+                                            <title>SI-1 - Procedure document</title>
+                                            <description>
+                                                <p>SI-1 System and Information Integrity Policy and Procedures - Procedure</p>
+                                            </description>
+                                            <prop
+                                                name="asset-type"
+                                                value="document" />
+                                            <link
+                                                href="#e472377c-487a-4201-8c2a-c04432acd58b"
+                                                rel="procedure" />
+                                            <status
+                                                state="operational" />
+                                        </component>
+                                    </system-implementation>
+                                    <control-implementation>
+                                        <implemented-requirement
+                                            control-id="si-1">
+                                            <by-component
+                                                component-uuid="cda2be7f-832f-45a6-9093-d3efbab3ea76"
+                                                uuid="da8f019b-05bf-4475-9955-ee9e65e534eb">
+                                                <description>
+                                                    <p>System and Information Integrity Policy and Procedures: procedure component reference</p>
+                                                </description>
+                                            </by-component>
+                                        </implemented-requirement>
+                                    </control-implementation>
+                                    <back-matter>
+                                        <resource
+                                            uuid="e472377c-487a-4201-8c2a-c04432acd58b">
+                                            <title>SI-1 System and Information Integrity Policy and Procedures - Procedures</title>
+                                            <prop
+                                                name="type"
+                                                value="procedure" />
+                                        </resource>
+                                    </back-matter>
+                                </system-security-plan>
+                            </x:context>
+                            <x:expect-not-assert
+                                id="has-procedure-link"
+                                label="that is correct" />
+                        </x:scenario>
+                        <x:scenario
+                            label="is absent">
+                            <x:context>
+                                <system-security-plan
+                                    xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                                    <system-implementation>
+                                        <component
+                                            type="procedure"
+                                            uuid="cda2be7f-832f-45a6-9093-d3efbab3ea76">
+                                            <title>SI-1 - Procedure document</title>
+                                            <description>
+                                                <p>SI-1 System and Information Integrity Policy and Procedures - Procedure</p>
+                                            </description>
+                                            <prop
+                                                name="asset-type"
+                                                value="document" />
+                                            <!--<link
+                                                href="#e472377c-487a-4201-8c2a-c04432acd58b"
+                                                rel="procedure" />-->
+                                            <status
+                                                state="operational" />
+                                        </component>
+                                    </system-implementation>
+                                    <control-implementation>
+                                        <implemented-requirement
+                                            control-id="si-1">
+                                            <by-component
+                                                component-uuid="cda2be7f-832f-45a6-9093-d3efbab3ea76"
+                                                uuid="da8f019b-05bf-4475-9955-ee9e65e534eb">
+                                                <description>
+                                                    <p>System and Information Integrity Policy and Procedures: procedure component reference</p>
+                                                </description>
+                                            </by-component>
+                                        </implemented-requirement>
+                                    </control-implementation>
+                                    <back-matter>
+                                        <resource
+                                            uuid="e472377c-487a-4201-8c2a-c04432acd58b">
+                                            <title>SI-1 System and Information Integrity Policy and Procedures - Procedures</title>
+                                            <prop
+                                                name="type"
+                                                value="procedure" />
+                                        </resource>
+                                    </back-matter>
+                                </system-security-plan>
+                            </x:context>
+                            <x:expect-assert
+                                id="has-procedure-link"
+                                label="that is an error" />
+                        </x:scenario>
+                    </x:scenario>
+
                     <x:scenario
                         label="when the procedure attachment resource">
                         <x:scenario


### PR DESCRIPTION
This PR extends policy and procedure artifact validations to component-based resource linking. The shortcoming was identified when #282 was changed.

Closes #296.