### PR TITLE
handles SSP 5.3.1.1 instance

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -644,7 +644,7 @@
                 name="leveraged"
                 value="/o:system-security-plan/o:system-implementation/o:component[@type='leveraged-system']"/>
             <sch:let 
-                name="controlID"
+                name="familyName"
                 value="substring-before(@control-id, '-')"/>
             <sch:let 
                 name="leveragedUUID"
@@ -653,7 +653,7 @@
                 diagnostics="leveraged-PE-controls-implemented-requirement-diagnostic"
                 id="leveraged-PE-controls-implemented-requirement"
                 role="warning"
-                test="if ($leveraged/@uuid eq $leveragedUUID and  $controlID eq 'pe')
+                test="if ($leveraged/@uuid eq $leveragedUUID and  $familyName eq 'pe')
                 then false()
                 else true()">This PE Control has a leveraged authorization - 
                 <xsl:value-of select="@control-id"/>.</sch:assert>            

--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -640,6 +640,23 @@
             <sch:let
                 name="missing"
                 value="$required-response-points[not(@id = $implemented/@statement-id)]" />
+            <sch:let
+                name="leveraged"
+                value="/o:system-security-plan/o:system-implementation/o:component[@type='leveraged-system']"/>
+            <sch:let 
+                name="controlID"
+                value="substring-before(@control-id, '-')"/>
+            <sch:let 
+                name="leveragedUUID"
+                value="prop[@name='leveraged-authorization-uuid']/@value"/>
+            <sch:assert 
+                diagnostics="leveraged-PE-controls-implemented-requirement-diagnostic"
+                id="leveraged-PE-controls-implemented-requirement"
+                role="warning"
+                test="if ($leveraged/@uuid eq $leveragedUUID and  $controlID eq 'pe')
+                then false()
+                else true()">This PE Control has a leveraged authorization - 
+                <xsl:value-of select="@control-id"/>.</sch:assert>            
             <sch:assert
                 diagnostics="invalid-implementation-status-diagnostic"
                 doc:checklist-reference="Section C Check 2"
@@ -3641,6 +3658,10 @@
             doc:assertion="leveraged-PE-controls"
             doc:context="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:statement/o:by-component"
             id="leveraged-PE-controls-diagnostic">There are PE controls inherited from leveraged authorizations.</sch:diagnostic>
+        <sch:diagnostic
+            doc:assertion="leveraged-PE-controls-implemented-requirement"
+            doc:context="/o:system-security-plan/o:control-implementation/o:implemented-requirement"
+            id="leveraged-PE-controls-implemented-requirement-diagnostic">There are PE controls inherited from leveraged authorizations.</sch:diagnostic>
         <sch:diagnostic
             doc:assertion="missing-component-description"
             doc:context="/o:system-security-plan/o:control-implementation/o:implemented-requirement/o:statement/o:by-component"

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -9702,7 +9702,33 @@
                     </system-security-plan>
                 </x:context>
                 <x:expect-not-assert
-                    id="PE-control-1"
+                    id="leveraged-PE-controls"
+                    label="that is correct" />
+            </x:scenario>
+            <x:scenario
+                label="When that is true">
+                <x:context>
+                    <system-security-plan
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                        <system-implementation>
+                            <component uuid="e82e6e07-0c62-417e-8a19-3744991b4c65" type="leveraged-system">
+                                <title>Name of Leveraged System</title>
+                                <description>
+                                    <p>If the leveraged system owner provides a UUID for their system (such as in an
+                                        OSCAL-based CRM), it should be reflected in the <code>inherited-uuid</code>
+                                        property.</p>
+                                </description>
+                            </component>
+                        </system-implementation>
+                        <control-implementation>
+                            <implemented-requirement uuid="uuid-value" control-id="pe-1">
+                                <prop name="leveraged-authorization-uuid" value="e82e6e07-0c62-417e-8a19-3744991b4c65"/>
+                            </implemented-requirement>
+                        </control-implementation>
+                    </system-security-plan>
+                </x:context>
+                <x:expect-not-assert
+                    id="leveraged-PE-controls-implemented-requirement"
                     label="that is correct" />
             </x:scenario>
         </x:scenario>


### PR DESCRIPTION
Updates to address leveraged-authorizations that are PE controls when the authorization property is a child of control-implementation/implemented-requirement.

This addresses the situation explained in SSP Guide 5.3.1.1.