### PR TITLE
Added test for prohibited vendor names

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -2121,6 +2121,18 @@
                 role="error"
                 test="not($is-infrastructure) or not(oscal:prop[(: @ns eq 'https://fedramp.gov/ns/oscal' and :)@name eq 'vendor-name'][2])">
                 "infrastructure" inventory item must have only one vendor-name property.</sch:assert>
+            <sch:let 
+                name="prohibit-vendor" 
+                value="'Dahua Technology Company', 'Dahua', 'Hangzhou Hikvision Digital Technology', 'Hangzhou', 'Hikvision', 
+                'Hangzhou Hikvision', 'Huawei', 'HyTera', 'Kaspersky Lab', 'Kaspersky', 'ZTE'"/>
+            <sch:assert
+                diagnostics="inventory-item-has-prohibited-vendor-name-diagnostic"
+                doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §6.5"
+                doc:template-reference="System Security Plan Template §15 Attachment 13"
+                id="inventory-item-has-prohibited-vendor-name"
+                role="warning"
+                test="not(o:prop[@name eq 'vendor-name']/@value = $prohibit-vendor)">The information system must not contain the banned vendor - 
+                '<xsl:value-of select="o:prop[@name eq 'vendor-name']/@value"/>'.  See FAR 889(a)(1)(B).</sch:assert>
             <!-- FIXME: perversely, hardware-model is not in FedRAMP @ns -->
             <sch:assert
                 diagnostics="inventory-item-has-hardware-model-diagnostic"
@@ -4221,6 +4233,10 @@
             doc:assertion="inventory-item-has-one-vendor-name"
             doc:context="oscal:inventory-item[oscal:prop[@name eq 'asset-type' and @value = ('os', 'infrastructure')]]"
             id="inventory-item-has-one-vendor-name-diagnostic">This inventory-item has more than one vendor-name property.</sch:diagnostic>
+        <sch:diagnostic
+            doc:assertion="inventory-item-has-prohibited-vendor-name"
+            doc:context="oscal:inventory-item[oscal:prop[@name eq 'vendor-name']]"
+            id="inventory-item-has-prohibited-vendor-name-diagnostic">This inventory-item contains a banned vendor.</sch:diagnostic>
         <sch:diagnostic
             doc:assertion="inventory-item-has-hardware-model"
             doc:context="oscal:inventory-item[oscal:prop[@name eq 'asset-type' and @value = ('os', 'infrastructure')]]"

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -6181,7 +6181,35 @@
                         id="inventory-item-has-one-vendor-name"
                         label="error" />
                 </x:scenario>
+            </x:scenario>            
+            <x:scenario
+                label="has an acceptable vendor-name value">
+                <x:context>
+                    <inventory-item
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                        <prop
+                            name="vendor-name" 
+                            value="Amazon"/>
+                    </inventory-item>
+                </x:context>
+                <x:expect-not-assert
+                    id="inventory-item-has-prohibited-vendor-name"
+                    label="that is correct" />
             </x:scenario>
+            <x:scenario
+                label="has a prohibited vendor-name value">
+                <x:context>
+                    <inventory-item
+                        xmlns="http://csrc.nist.gov/ns/oscal/1.0">
+                        <prop
+                            name="vendor-name"
+                            value="Huawei"/>
+                    </inventory-item>
+                </x:context>
+                <x:expect-assert
+                    id="inventory-item-has-prohibited-vendor-name"
+                    label="that is an error" />
+            </x:scenario>            
             <x:scenario
                 label="&quot;infrastructure&quot; asset-type has a hardware-model property.">
                 <x:scenario


### PR DESCRIPTION
Only tests for inventory-item/prop[@name='vendor-name'] as described in the [story](https://github.com/18F/fedramp-automation/issues/306).

The list is taken from the story which was taken from this [FAR document](https://www.federalregister.gov/documents/2020/07/14/2020-15293/federal-acquisition-regulation-prohibition-on-contracting-with-entities-using-certain). 

The list is hard coded to the schematron and not dynamically updated from any external source.