### PR TITLE
create use-debug-mode

### DIFF
--- a/src/validations/rules/ssp.sch
+++ b/src/validations/rules/ssp.sch
@@ -203,6 +203,18 @@
         name="use-remote-resources"
         value="$param-use-remote-resources or matches(lower-case(environment-variable('use_remote_resources')), '1|true') " />
 
+    <!-- setting for use of debug mode -->
+    <!-- XSLT parameter param-use-debug-mode -->
+    <xsl:param
+        as="xs:boolean"
+        name="param-use-debug-mode"
+        select="false()" />
+    
+    <!-- schematron variable use-debug-mode -->
+    <sch:let
+        name="use-debug-mode"
+        value="$param-use-debug-mode or matches(lower-case(environment-variable('use_debug_mode')), '1|true')" />
+    
     <sch:pattern
         id="parameters-and-variables">
         <sch:rule
@@ -211,13 +223,13 @@
             <sch:report
                 id="parameter-use-remote-resources"
                 role="information"
-                test="true()">parameter use-remote-resources is <sch:value-of
+                test="$use-debug-mode eq true()">parameter use-remote-resources is <sch:value-of
                     select="$param-use-remote-resources" />.</sch:report>
 
             <sch:report
                 id="environment-variable-use-remote-resources"
                 role="information"
-                test="true()">environment-variable use_remote_resources is <sch:value-of
+                test="$use-debug-mode eq true()">environment-variable use_remote_resources is <sch:value-of
                     select="
                         if (environment-variable('use_remote_resources') ne '') then
                             environment-variable('use_remote_resources')
@@ -227,9 +239,30 @@
             <sch:report
                 id="variable-use-remote-resources"
                 role="information"
-                test="true()">variable use-remote-resources is <sch:value-of
+                test="$use-debug-mode eq true()">variable use-remote-resources is <sch:value-of
                     select="$use-remote-resources" />.</sch:report>
 
+            <sch:report
+                id="parameter-use-debug-mode"
+                role="information"
+                test="$use-debug-mode eq true()">parameter use-debug-mode is <sch:value-of
+                    select="$param-use-debug-mode" />.</sch:report>
+
+            <sch:report
+                id="environment-variable-use-debug-mode"
+                role="information"
+                test="$use-debug-mode eq true()">environment-variable use_debug_mode is <sch:value-of
+                    select="
+                        if (environment-variable('use_debug_mode') ne '') then
+                            environment-variable('use_debug_mode')
+                        else
+                            'not defined'" />.</sch:report>
+            
+            <sch:report
+                id="variable-use-debug-mode"
+                role="information"
+                test="$use-debug-mode eq true()">variable use-debug-mode is <sch:value-of
+                    select="$use-debug-mode" />.</sch:report>
         </sch:rule>
     </sch:pattern>
 
@@ -536,7 +569,7 @@
                 doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5"
                 id="implemented-response-points"
                 role="information"
-                test="true()">A FedRAMP SSP must implement a statement for each of the following lettered response points for required controls: <sch:value-of
+                test="$use-debug-mode eq true()">A FedRAMP SSP must implement a statement for each of the following lettered response points for required controls: <sch:value-of
                     select="$implemented/@statement-id" />.</sch:report>
         </sch:rule>        
         <sch:rule
@@ -581,7 +614,7 @@
                 doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5"
                 id="each-required-control-report"
                 role="information"
-                test="true()">Sensitivity-level is <sch:value-of
+                test="$use-debug-mode eq true()">Sensitivity-level is <sch:value-of
                     select="$sensitivity-level" />, the following <sch:value-of
                     select="count($required-controls)" />
                 <sch:value-of
@@ -625,7 +658,7 @@
                 doc:guide-reference="Guide to OSCAL-based FedRAMP System Security Plans §5"
                 id="control-implemented-requirements-stats"
                 role="information"
-                test="count($results/errors/error) = 0">
+                test="count($results/errors/error) = 0 and $use-debug-mode eq true()">
                 <sch:value-of
                     select="$results => lv:report() => normalize-space()" />.</sch:report>
         </sch:rule>

--- a/src/validations/test/ssp.xspec
+++ b/src/validations/test/ssp.xspec
@@ -359,21 +359,6 @@
                 <x:scenario
                     label="and requirements are implemented">
                     <x:scenario
-                        label="a count of all total controls">
-                        <x:context>
-                            <system-security-plan
-                                xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-                                <system-characteristics>
-                                    <security-sensitivity-level>fips-199-low</security-sensitivity-level>
-                                </system-characteristics>
-                                <control-implementation />
-                            </system-security-plan>
-                        </x:context>
-                        <x:expect-report
-                            id="each-required-control-report"
-                            label="must be reported." />
-                    </x:scenario>
-                    <x:scenario
                         label="and any control's implemented requirement is defined with an invalid status">
                         <x:context>
                             <system-security-plan
@@ -398,32 +383,6 @@
                         <x:expect-assert
                             id="invalid-implementation-status"
                             label="it is invalid." />
-                    </x:scenario>
-                    <x:scenario
-                        label="summary counts of controls' implementated requirements and those with valid and invalid statuses">
-                        <x:context>
-                            <system-security-plan
-                                xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-                                <system-characteristics>
-                                    <security-sensitivity-level>fips-199-low</security-sensitivity-level>
-                                </system-characteristics>
-                                <control-implementation>
-                                    <implemented-requirement
-                                        control-id="cm-1"
-                                        uuid="eee8697a-bc39-45aa-accc-d3e534932efb">
-                                        <prop
-                                            name="implementation-status"
-                                            ns="https://fedramp.gov/ns/oscal"
-                                            value="implemented">
-                                            <remarks />
-                                        </prop>
-                                    </implemented-requirement>
-                                </control-implementation>
-                            </system-security-plan>
-                        </x:context>
-                        <x:expect-report
-                            id="control-implemented-requirements-stats"
-                            label="must be reported." />
                     </x:scenario>
                 </x:scenario>
                 <x:scenario
@@ -577,65 +536,6 @@
                 </x:scenario>
                 <x:scenario
                     label="and the profile defines specific response points to address specific control requirements">
-                    <x:scenario
-                        label="and response points are properly defined">
-                        <x:context>
-                            <system-security-plan
-                                xmlns="http://csrc.nist.gov/ns/oscal/1.0">
-                                <system-characteristics>
-                                    <security-sensitivity-level>fips-199-low</security-sensitivity-level>
-                                </system-characteristics>
-                                <system-implementation>
-                                    <component
-                                        component-type="system"
-                                        uuid="5129f6ad-53f7-47be-9e5c-22728012264a">
-                                        <title>This System</title>
-                                        <description>
-                                            <p>This component is referenced in the implemented requirement.</p>
-                                        </description>
-                                        <status
-                                            state="operational" />
-                                    </component>
-                                </system-implementation>
-                                <control-implementation>
-                                    <!-- Requirements and lettered responses for AC-7 are complete, so these will be absent from the report. -->
-                                    <implemented-requirement
-                                        control-id="ac-7"
-                                        uuid="c1a9916f-cba6-4910-b2ea-b4ba17b03480">
-                                        <prop
-                                            name="implementation-status"
-                                            ns="https://fedramp.gov/ns/oscal"
-                                            value="implemented" />
-                                        <statement
-                                            statement-id="ac-7_smt.a"
-                                            uuid="8d8e73f3-b966-4b3e-a545-93923885ba2a">
-                                            <by-component
-                                                component-uuid="5129f6ad-53f7-47be-9e5c-22728012264a"
-                                                uuid="fa680b3c-9da9-443f-9a4c-db731a5218f7">
-                                                <description>
-                                                    <p>This describes how component 'This System' is used to satisfy the control requirements.</p>
-                                                </description>
-                                            </by-component>
-                                        </statement>
-                                        <statement
-                                            statement-id="ac-7_smt.b"
-                                            uuid="5794c9a0-01c5-499e-b58f-1beed1585576">
-                                            <by-component
-                                                component-uuid="5129f6ad-53f7-47be-9e5c-22728012264a"
-                                                uuid="34afa29a-c258-42fb-b08d-0c21be7f814d">
-                                                <description>
-                                                    <p>This describes how component 'This System' is used to satisfy the control requirements.</p>
-                                                </description>
-                                            </by-component>
-                                        </statement>
-                                    </implemented-requirement>
-                                </control-implementation>
-                            </system-security-plan>
-                        </x:context>
-                        <x:expect-report
-                            id="implemented-response-points"
-                            label="those defined are validated." />
-                    </x:scenario>
                     <x:scenario
                         label="and response points are missing">
                         <x:context>


### PR DESCRIPTION
ssp.sch
* created xslt param for $use-debug-mode
* created $use-debug-mode schematron variable
* set reports for parameters-and-variables to check for $use-debug-mode eq true()
* created reports for use-debug-mode for parameter and env var.
* added $use-debug-mode eq true() test to:
  * each-required-control-report
  * implemented-response-points
  * control-implemented-requirements-stats

ssp.xspec
* removed following x:scenario elements
  * 'and response points are properly defined'
  * 'a count of all total controls'
  * 'summary counts of controls' implementated requirements and those with valid and invalid statuses'

closes #471 