### PR TITLE
Fix dist validation paths

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -27,5 +27,5 @@ jobs:
       - uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: dist/validations/ssp.xsl
+          artifacts: dist/validations/**
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ build: build-validations build-web dist  ## Build all artifacts and copy into di
 
 	# Copy validations
 	mkdir -p dist/validations
-	cp src/validations/target/ssp.xsl dist/validations
-	cp -r src/validations/rules/ssp.sch dist/validations
+	cp src/validations/target/rules/*.xsl dist/validations
+	cp src/validations/rules/*.sch dist/validations


### PR DESCRIPTION
Copy all the new Schematron artifacts into the `dist/validations` directory. Follow-on work to #467.