### PR TITLE
Show xml parsing errors

### DIFF
--- a/src/web/src/browser/presenter/actions/validator.ts
+++ b/src/web/src/browser/presenter/actions/validator.ts
@@ -27,7 +27,9 @@ export const setSspFile = async (
         }),
       )
       .then(actions.validator.annotateXml)
-      .catch(actions.validator.setProcessingError);
+      .catch((error: Error) =>
+        actions.validator.setProcessingError(error.message),
+      );
   }
 };
 

--- a/src/web/src/browser/views/components/ValidatorFileSelectForm.tsx
+++ b/src/web/src/browser/views/components/ValidatorFileSelectForm.tsx
@@ -99,6 +99,16 @@ export const ValidatorFileSelectForm = () => {
             </li>
           ))}
         </ul>
+        {schematron.validator.current === 'PROCESSING_ERROR' && (
+          <div className="usa-alert usa-alert--error" role="alert">
+            <div className="usa-alert__body">
+              <h4 className="usa-alert__heading">Processing Error</h4>
+              <p className="usa-alert__text">
+                {schematron.validator.errorMessage}
+              </p>
+            </div>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
#493 Show exception text when there is an unexpected validation error. Ultimately, this is the raw text of the SaxonJS exception. Example error:
![image](https://user-images.githubusercontent.com/136512/169118906-d32341d9-7531-4b63-897a-f5af2762302e.png)
