### PR TITLE
Support resetting validation state after an error

### DIFF
--- a/src/web/src/browser/presenter/actions/validator.ts
+++ b/src/web/src/browser/presenter/actions/validator.ts
@@ -3,9 +3,7 @@ import type { ValidationReport } from '@asap/shared/use-cases/schematron';
 import type { PresenterConfig } from '..';
 
 export const reset = ({ state }: PresenterConfig) => {
-  if (state.schematron.validator.matches('VALIDATED')) {
-    state.schematron.validator.send('RESET');
-  }
+  state.schematron.validator.send('RESET');
 };
 
 export const setSspFile = async (


### PR DESCRIPTION
One more tweak to support documents with errors: this fix enables validating another document after the UI is in an error state. Builds on: #493 #497