### PR TITLE
Doc fix: Inherit parent XSpec scenario's context if unspecified

### DIFF
--- a/src/web/src/shared/domain/xspec.test.ts
+++ b/src/web/src/shared/domain/xspec.test.ts
@@ -31,6 +31,14 @@ describe('xspec', () => {
           label: 'child 3',
         },
       ],
+      'assertion-4': [
+        {
+          assertionId: 'assertion-4',
+          assertionLabel: 'assertion-4 label',
+          context: '<middle-parent-context></middle-parent-context>',
+          label: 'parent 1 middle parent child 4 no context',
+        },
+      ],
     });
   });
 });
@@ -42,6 +50,7 @@ const MOCK_XSPEC = {
       scenarios: [
         {
           label: 'middle parent',
+          context: '<middle-parent-context></middle-parent-context>',
           scenarios: [
             {
               label: 'child 1',
@@ -60,6 +69,15 @@ const MOCK_XSPEC = {
                 {
                   id: 'assertion-2',
                   label: 'assertion-2 label',
+                },
+              ],
+            },
+            {
+              label: 'child 4 no context',
+              expectNotAssert: [
+                {
+                  id: 'assertion-4',
+                  label: 'assertion-4 label',
                 },
               ],
             },

--- a/src/web/src/shared/domain/xspec.ts
+++ b/src/web/src/shared/domain/xspec.ts
@@ -39,14 +39,19 @@ export const getXSpecScenarioSummaries = async (
   const getScenarios = (
     scenario: XSpecScenario,
     parentLabel?: string,
+    parentContext?: string,
   ): ScenarioSummary[] => {
+    // This scenario's label is the concatenation of all parent labels.
     const label = parentLabel
       ? [parentLabel, scenario.label].join(' ')
       : scenario.label;
 
+    // The context for this scenario is either specified on the node, or inherited.
+    const context = scenario.context || parentContext;
+
     // If there are child scenarios, recurse over ourself.
     if (scenario.scenarios) {
-      return scenario.scenarios.flatMap(s => getScenarios(s, label));
+      return scenario.scenarios.flatMap(s => getScenarios(s, label, context));
     }
 
     const assertions = [
@@ -58,7 +63,7 @@ export const getXSpecScenarioSummaries = async (
     const finalScenarios = assertions.map(assertion => ({
       assertionId: assertion.id,
       assertionLabel: assertion.label,
-      context: scenario.context ? formatXml(scenario.context) : '',
+      context: context ? formatXml(context) : '',
       label,
     }));
 


### PR DESCRIPTION
Fixes #524 - inherit parent XSpec scenario's context if unspecified.

The example scenario in #524 now looks like this:

![image](https://user-images.githubusercontent.com/136512/172486283-6f8feecf-e9a3-4142-9aa9-324cf70fb18c.png)
