### PR TITLE
gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,9 @@ src/validations/test/rules/sar-result.html
 src/validations/test/rules/ssp-result.html
 src/validations/test/rules/sap-result.html
 
+# XSpec artifacts (from OxygenXML XSpec use)
+src/validations/test/rules/xspec
+
 # OxygenXML project files
 *.xpr
+


### PR DESCRIPTION
Added exclusion for `src/validations/test/rules/xspec` (OxygenXML Editor leaves ephemeral XSpec stuff here).