### PR TITLE
Create dist archive as zip instead of tarball, for compatibility.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
         run: make init build
 
       - name: Create release archive
-        run: tar -zcf fedramp-automation.tar.gz dist
+        run: mv dist fedramp-automation && zip fedramp-automation.zip fedramp-automation
 
       # Create a release corresponding to the triggered tag
       - uses: ncipollo/release-action@v1


### PR DESCRIPTION
More tweaks building on #561. This creates a zip instead of tarball, and renames the target directory `fedramp-automation`. Sorry for all the noise - I'm merging these and then testing the full release workflow.