### PR TITLE
Add a "please wait" indicator

### DIFF
--- a/src/web/src/browser/views/components/ValidatorFileSelectForm.tsx
+++ b/src/web/src/browser/views/components/ValidatorFileSelectForm.tsx
@@ -112,8 +112,10 @@ export const ValidatorFileSelectForm = () => {
           )}
         </div>
         {state.validator.current === 'PROCESSING' && (
-          <div className="usa-hint loader-message">
-            Please wait, this document is still processing...
+          <div className="z-top usa-hint loader-message">
+            <div className="loader-message-text">
+              Please wait, this document is still processing...
+            </div>
           </div>
         )}
       </div>

--- a/src/web/src/browser/views/components/ValidatorFileSelectForm.tsx
+++ b/src/web/src/browser/views/components/ValidatorFileSelectForm.tsx
@@ -111,6 +111,11 @@ export const ValidatorFileSelectForm = () => {
             </svg>
           )}
         </div>
+        {state.validator.current === 'PROCESSING' && (
+          <div className="usa-hint loader-message">
+            Please wait, this document is still processing...
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/web/src/browser/views/styles/index.scss
+++ b/src/web/src/browser/views/styles/index.scss
@@ -69,20 +69,6 @@
   }
 }
 
-@keyframes pulsate {
-  0% {
-    opacity: 1.0;
-  }
-
-  50% {
-    opacity: 0.5;
-  }
-
-  100% {
-    opacity: 1.0;
-  }
-}
-
 // Header & Navigation
 .beta-banner {
   background-color: color('accent-cool-lighter');

--- a/src/web/src/browser/views/styles/index.scss
+++ b/src/web/src/browser/views/styles/index.scss
@@ -37,8 +37,49 @@
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
+  }
+}
+
+.loader-message {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  margin: 1em;
+  background-color: white;
+  font-size: 2em;
+  opacity: 0;
+  animation: fadeIn 1s;
+  animation-delay: 10s;
+  animation-fill-mode: forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes pulsate {
+  0% {
+    opacity: 1.0;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+
+  100% {
+    opacity: 1.0;
   }
 }
 

--- a/src/web/src/browser/views/styles/index.scss
+++ b/src/web/src/browser/views/styles/index.scss
@@ -44,19 +44,21 @@
 }
 
 .loader-message {
-  position: absolute;
+  position: fixed;
   top: 0;
   bottom: 0;
   left: 0;
   right: 0;
-  text-align: center;
-  margin: 1em;
-  background-color: white;
+  margin: 2em;
   font-size: 2em;
+  text-align: center;
   opacity: 0;
   animation: fadeIn 1s;
   animation-delay: 10s;
   animation-fill-mode: forwards;
+  .loader-message-text {
+    background-color: white;
+  }
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
This is a workaround for #600.

Add a "please wait" message that displays after 10 seconds of XSLT processing. The delay utilizes CSS animations so a locked-up UI thread does not prevent the delayed display.

Any suggestions on choice of language or visuals would be helpful.