### PR TITLE
Remove XSpec report publishing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,32 +54,3 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           make test-validations test-web
-
-      # Sets the test report path for visibility
-      - name: Publish XSpec Test Results
-        uses: mikepenz/action-junit-report@v1
-        if: runner.os == 'Linux'
-        with:
-          report_paths: "**/report/test/*junit.xml"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Publish the test summary as comment on the PR
-      - name: Publish XSpec Test Results Summary
-        uses: EnricoMi/publish-unit-test-result-action@v1.15
-        if: runner.os == 'Linux'
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          check_name: XSpec Test Results
-          files: "**/report/test/*junit.xml"
-          report_individual_runs: true
-          deduplicate_classes_by_file_name: false
-
-      - name: Upload Resulting Schematron SVRL Report
-        uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6 # v2
-        if: runner.os == 'Linux'
-        with:
-          name: fedramp-automation-validation-unit-tests-${{ github.sha }}
-          path: |
-            ./src/validations/report/schematron/**/*.*
-            ./src/validations/report/test/**/*.*
-          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -8,7 +8,5 @@
     "federalist": "make init-repo && npm run build:validation-ui && npm run link:validation-ui",
     "link:validation-ui": "ln -sf ./src/web/dist _site"
   },
-  "dependencies": {
-    "saxon-js": "^2.4.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Remove XSpec report from test runner workflow. This PR adds the "XSpec Test Report" comment to each PR, and is rather noisy.